### PR TITLE
[35] fix(rbac): teto de prioridade fecha quatro escaladas de privilégio

### DIFF
--- a/app/Http/Controllers/PermissionRole/AssignRoleController.php
+++ b/app/Http/Controllers/PermissionRole/AssignRoleController.php
@@ -15,6 +15,7 @@ use App\Services\RoleFilterService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 
 final class AssignRoleController extends Controller
@@ -55,6 +56,25 @@ final class AssignRoleController extends Controller
         // Impede que usuário altere seu próprio cargo (verifica o usuário efetivo, não o impersonado)
         if ($effectiveUser->id === $user->id) {
             return redirect()->back()->withErrors(['error' => 'Você não pode alterar o seu próprio cargo!']);
+        }
+
+        // Teto sobre o cargo ATUAL do alvo. As validações abaixo só olham o cargo
+        // NOVO, então sem esta guarda um gerente (70) rebaixava um administrador
+        // (90) para `viewer` — cargo que ele pode atribuir, sobre alguém em quem
+        // não deveria tocar. Mesma regra do UserPolicy, com o ator real por trás
+        // da impersonação.
+        if (Gate::denies('assignRole', $user)) {
+            Log::warning('User attempted to change the role of a user at or above their own priority', [
+                'auth_user_id'      => $authUser->id,
+                'effective_user_id' => $effectiveUser->id,
+                'target_user_id'    => $user->id,
+                'target_user_role'  => $user->role?->name,
+                'is_impersonating'  => $this->impersonationService->isImpersonating(),
+            ]);
+
+            return redirect()->back()->withErrors([
+                'error' => 'Você não pode alterar o cargo deste usuário!',
+            ]);
         }
 
         // Validação de prioridade: só pode atribuir roles com prioridade menor (usa usuário efetivo)

--- a/app/Http/Controllers/PermissionRole/RevokeRoleController.php
+++ b/app/Http/Controllers/PermissionRole/RevokeRoleController.php
@@ -15,6 +15,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 
 final class RevokeRoleController extends Controller
@@ -45,6 +46,24 @@ final class RevokeRoleController extends Controller
         // Impede que usuário remova cargo de si mesmo (verifica o usuário efetivo)
         if ($effectiveUser->id === $user->id) {
             return redirect()->back()->withErrors(['error' => 'Você não pode remover o seu próprio cargo!']);
+        }
+
+        // Teto sobre o cargo ATUAL do alvo. A checagem abaixo pergunta apenas se
+        // o ator poderia atribuir `visitor` — e todo mundo com `assign_roles`
+        // pode, porque `visitor` é o piso. Sem esta guarda, um gerente (70)
+        // jogava o administrador (90) em `visitor` e o trancava fora do painel.
+        if (Gate::denies('assignRole', $user)) {
+            Log::warning('User attempted to revoke the role of a user at or above their own priority', [
+                'auth_user_id'      => $authUser->id,
+                'effective_user_id' => $effectiveUser->id,
+                'target_user_id'    => $user->id,
+                'target_user_role'  => $user->role?->name,
+                'is_impersonating'  => $this->impersonationService->isImpersonating(),
+            ]);
+
+            return redirect()->back()->withErrors([
+                'error' => 'Você não pode remover o cargo deste usuário!',
+            ]);
         }
 
         // Verifica se pode atribuir o role VISITOR (mesma validação de prioridade)

--- a/app/Http/Controllers/PermissionRole/SyncPermissionsController.php
+++ b/app/Http/Controllers/PermissionRole/SyncPermissionsController.php
@@ -16,7 +16,7 @@ final class SyncPermissionsController extends Controller
 {
     public function __invoke(SyncPermissionsRequest $request, User $user): RedirectResponse
     {
-        Gate::authorize('managePermissions', $user);
+        Gate::authorize('mutatePermissions', $user);
 
         $permissionIds = Permission::getIdsFromNames($request->validated('permissions') ?? []);
 

--- a/app/Http/Controllers/PermissionRole/UpdateController.php
+++ b/app/Http/Controllers/PermissionRole/UpdateController.php
@@ -1,18 +1,27 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace App\Http\Controllers\PermissionRole;
 
+use App\Enum\Permissions;
 use App\Enum\Roles as RolesEnum;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\PermissionRole\UpdateRolePermissionsRequest;
 use App\Models\Permission;
 use App\Models\Role;
 use App\Models\User;
+use App\Services\ImpersonationService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Cache;
 
-class UpdateController extends Controller
+final class UpdateController extends Controller
 {
+    public function __construct(
+        private readonly ImpersonationService $impersonationService
+    ) {
+    }
+
     public function __invoke(UpdateRolePermissionsRequest $request, string $roleName): RedirectResponse
     {
         $allowedRoleNames = array_map(
@@ -25,6 +34,8 @@ class UpdateController extends Controller
         $role = Role::where('name', $roleName)->firstOrFail();
 
         $permissionNames = $request->validated('permissions', []);
+
+        $this->ensureActorMayEdit($request, $role, $permissionNames);
 
         $role->permissions()->sync(Permission::getIdsFromNames($permissionNames));
 
@@ -46,5 +57,76 @@ class UpdateController extends Controller
             });
 
         return redirect()->back()->with('success', "Permissões de {$role->label} atualizadas com sucesso!");
+    }
+
+    /**
+     * `can:manage_roles` responde "pode mexer em cargo?", nunca "pode mexer
+     * NESTE cargo, com ESTAS permissões?" — e essa diferença era uma escada.
+     *
+     * O `PermissionRoleSeeder` tira `impersonate_users` do administrador de
+     * propósito. Mas o administrador tem `manage_roles`: ele abria a tela de
+     * Cargos, marcava a caixa no PRÓPRIO cargo e anulava a exclusão. Um PUT
+     * direto no cargo `super_user` — que a tela nem lista para ele — deixava o
+     * suporte com zero permissões, sem caminho de volta pelo painel.
+     *
+     * Proteger isso só pela matriz seria proteger com a chave dentro da
+     * fechadura, porque é esta mesma tela que distribui `manage_roles`.
+     *
+     * Duas regras, as mesmas do `UserPolicy`: só se mexe em cargo de prioridade
+     * ESTRITAMENTE menor, e só se concede permissão que o próprio ator tem.
+     *
+     * @param list<string> $permissions
+     */
+    private function ensureActorMayEdit(UpdateRolePermissionsRequest $request, Role $role, array $permissions): void
+    {
+        $actor = $this->realActor($request);
+
+        if ($actor->hasRole(RolesEnum::SUPER_USER)) {
+            /*
+             * O suporte monta qualquer cargo — menos tirar de si mesmo o que o
+             * traz de volta a esta tela. Um "desmarcar tudo" no próprio cargo
+             * trancaria a operação fora do editor, com saída só por shell.
+             */
+            if ($role->isSuperUser() && !in_array(Permissions::MANAGE_ROLES->value, $permissions, true)) {
+                abort(403, sprintf(
+                    'Você não pode tirar "%s" do seu próprio cargo — seria perder o acesso a esta tela.',
+                    Permissions::MANAGE_ROLES->label()
+                ));
+            }
+
+            return;
+        }
+
+        if ($role->getPriority() >= ($actor->role?->getPriority() ?? 0)) {
+            abort(403, 'Você não pode alterar as permissões deste cargo.');
+        }
+
+        // `getAllPermissions()` soma cargo + permissões individuais: é a
+        // superfície real do ator, e é ela que ele pode repassar.
+        $concedeAlemDoProprio = array_diff($permissions, $actor->getAllPermissions()->pluck('name')->all());
+
+        if ($concedeAlemDoProprio !== []) {
+            abort(403, 'Você não pode conceder um acesso que você mesmo não tem.');
+        }
+    }
+
+    /**
+     * Quem manda é o humano por trás da sessão, não a persona impersonada —
+     * mesma leitura do `UserPolicy::effectiveActor()`. Sem isto, vestir um cargo
+     * mais alto viraria o caminho para editar cargos.
+     */
+    private function realActor(UpdateRolePermissionsRequest $request): User
+    {
+        $actor = $this->impersonationService->getOriginalUser() ?? $request->user();
+
+        if ($actor === null) {
+            abort(401, 'Usuário não autenticado');
+        }
+
+        if (!$actor->relationLoaded('role')) {
+            $actor->load('role');
+        }
+
+        return $actor;
     }
 }

--- a/app/Http/Controllers/User/GrantPermissionController.php
+++ b/app/Http/Controllers/User/GrantPermissionController.php
@@ -20,7 +20,7 @@ final class GrantPermissionController extends Controller
 
     public function __invoke(GrantPermissionRequest $request, User $user): RedirectResponse
     {
-        Gate::authorize('managePermissions', $user);
+        Gate::authorize('mutatePermissions', $user);
 
         $this->permissionManagementService->grantPermissionToUser(
             user: $user,

--- a/app/Http/Controllers/User/RevokePermissionController.php
+++ b/app/Http/Controllers/User/RevokePermissionController.php
@@ -20,7 +20,7 @@ final class RevokePermissionController extends Controller
 
     public function __invoke(User $user, string $permission): RedirectResponse
     {
-        Gate::authorize('managePermissions', $user);
+        Gate::authorize('mutatePermissions', $user);
 
         $permissionModel = Permission::where('name', $permission)->firstOrFail();
 

--- a/app/Http/Requests/PermissionRole/UpdateRolePermissionsRequest.php
+++ b/app/Http/Requests/PermissionRole/UpdateRolePermissionsRequest.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace App\Http\Requests\PermissionRole;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class UpdateRolePermissionsRequest extends FormRequest
+final class UpdateRolePermissionsRequest extends FormRequest
 {
     public function authorize(): bool
     {
@@ -23,6 +25,9 @@ class UpdateRolePermissionsRequest extends FormRequest
         ];
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function messages(): array
     {
         return [

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -4,8 +4,20 @@ declare(strict_types = 1);
 
 namespace App\Policies;
 
+use App\Enum\Roles;
 use App\Models\User;
+use App\Services\ImpersonationService;
 
+/**
+ * `manage_users` sozinho não basta. Sem checagem de prioridade, quem tivesse a
+ * permissão trocava a **senha e o e-mail** de qualquer outro portador dela —
+ * inclusive de quem estivesse acima — e assumia a conta. Na matriz do
+ * `PermissionRoleSeeder`, `manage_users` vai para `super_user` (100), `admin`
+ * (90) e `manager` (70): o gerente excluía o administrador, e dois
+ * administradores eram pares agindo um sobre o outro.
+ *
+ * Daqui em diante, ação sobre alguém de prioridade **igual ou maior** é negada.
+ */
 class UserPolicy
 {
     public function viewAny(User $user): bool
@@ -29,22 +41,13 @@ class UserPolicy
             return false;
         }
 
-        $isSuperUser = $user->hasRole('super_user');
-
         // Impede que o usuário altere seu próprio status ativo/inativo
         // Isso deve ser feito através do perfil ou por outro administrador
-        // EXCETO: SUPER_USER pode alterar status de qualquer usuário (exceto o seu próprio)
-        if ($user->id === $model->id && request()->has('is_active')) {
+        if ($this->isSelf($user, $model) && request()->has('is_active')) {
             return false;
         }
 
-        // SUPER_USER pode editar qualquer usuário, incluindo outros SUPER_USER
-        if ($isSuperUser) {
-            return true;
-        }
-
-        // Outros usuários não podem editar super_user
-        return !$model->hasRole('super_user');
+        return $this->outranks($user, $model);
     }
 
     public function delete(User $user, User $model): bool
@@ -54,17 +57,11 @@ class UserPolicy
         }
 
         // Impede auto-exclusão
-        if ($user->id === $model->id) {
+        if ($this->isSelf($user, $model)) {
             return false;
         }
 
-        // SUPER_USER pode deletar qualquer usuário, incluindo outros SUPER_USER
-        if ($user->hasRole('super_user')) {
-            return true;
-        }
-
-        // Outros usuários não podem deletar super_user
-        return !$model->hasRole('super_user');
+        return $this->outranks($user, $model);
     }
 
     public function toggleActive(User $user, User $model): bool
@@ -74,17 +71,11 @@ class UserPolicy
         }
 
         // Impede que o usuário desative a si mesmo
-        if ($user->id === $model->id) {
+        if ($this->isSelf($user, $model)) {
             return false;
         }
 
-        // SUPER_USER pode desativar qualquer usuário, incluindo outros SUPER_USER
-        if ($user->hasRole('super_user')) {
-            return true;
-        }
-
-        // Outros usuários não podem desativar super_user
-        return !$model->hasRole('super_user');
+        return $this->outranks($user, $model);
     }
 
     public function impersonate(User $user, User $model): bool
@@ -92,8 +83,103 @@ class UserPolicy
         return $user->canImpersonate($model);
     }
 
+    /**
+     * **Leitura** da matriz de permissões de alguém (`users.permissions.show`).
+     * Sem teto de propósito: quem administra usuários precisa enxergar o que
+     * cada conta pode fazer, inclusive contas acima da sua. Para mutar, veja
+     * `mutatePermissions()`.
+     */
     public function managePermissions(User $user): bool
     {
         return $user->hasPermissionTo('manage_permissions');
+    }
+
+    /**
+     * **Mutação** das permissões individuais de outro usuário (grant/revoke/sync).
+     *
+     * O `managePermissions()` acima ignora o alvo — a assinatura tem um único
+     * parâmetro e o PHP descarta o argumento extra que os call sites passam —,
+     * então qualquer portador de `manage_permissions` atingia qualquer conta,
+     * inclusive a própria: um administrador auto-concedia `impersonate_users`,
+     * exatamente a permissão que o seeder lhe nega. Aqui o alvo precisa ter
+     * prioridade estritamente menor que a do ator real, o que também barra o
+     * auto-alvo.
+     */
+    public function mutatePermissions(User $user, User $model): bool
+    {
+        if (!$user->hasPermissionTo('manage_permissions')) {
+            return false;
+        }
+
+        return $this->outranks($user, $model);
+    }
+
+    /**
+     * Atribuir/remover o CARGO de outro usuário (rotas `user.assign-role` e
+     * `user.revoke-role`). Essas rotas checavam o cargo NOVO contra o ator e
+     * nunca o cargo ATUAL do alvo: um gerente (70) rebaixava o administrador
+     * (90) para `viewer`, ou o jogava em `visitor` pelo revoke — travando a
+     * organização fora do painel, sem caminho de volta pela interface.
+     */
+    public function assignRole(User $user, User $model): bool
+    {
+        if (!$user->hasPermissionTo('assign_roles')) {
+            return false;
+        }
+
+        if ($this->isSelf($user, $model)) {
+            return false;
+        }
+
+        return $this->outranks($user, $model);
+    }
+
+    /**
+     * Teto de autoridade: o alvo precisa ter prioridade ESTRITAMENTE menor.
+     * `super_user` segue como estava — edita, desativa e exclui qualquer um,
+     * inclusive outro `super_user`.
+     */
+    private function outranks(User $user, User $model): bool
+    {
+        $actor = $this->effectiveActor($user);
+
+        if ($actor->hasRole(Roles::SUPER_USER)) {
+            return true;
+        }
+
+        return $this->priority($actor) > $this->priority($model);
+    }
+
+    /**
+     * **Quem manda é o usuário real, não a persona impersonada.**
+     *
+     * A permissão continua sendo lida na persona (impersonar precisa reproduzir
+     * o que aquele usuário consegue fazer), mas o teto de autoridade é do humano
+     * por trás da sessão — senão impersonar vira escada: `canImpersonateAny()`
+     * (meta da permissão `impersonate_users`) ignora a prioridade, então um
+     * gerente que a tivesse poderia vestir o administrador e, de dentro dele,
+     * editar outros administradores. Mesma leitura que o `RoleFilterService` e o
+     * `AssignRoleController` já fazem.
+     */
+    private function effectiveActor(User $user): User
+    {
+        return app(ImpersonationService::class)->getOriginalUser() ?? $user;
+    }
+
+    /**
+     * Sem cargo = prioridade 0: não supera ninguém, nem outro sem cargo.
+     */
+    private function priority(User $user): int
+    {
+        return $user->role?->getPriority() ?? 0;
+    }
+
+    /**
+     * Vale para a persona E para o usuário real: um administrador impersonando
+     * um gerente não pode excluir nem desativar a própria conta de administrador.
+     */
+    private function isSelf(User $user, User $model): bool
+    {
+        return $model->id === $user->id || $model->id === $this->effectiveActor($user)->id;
     }
 }

--- a/tests/Feature/PermissionRole/UpdateControllerTest.php
+++ b/tests/Feature/PermissionRole/UpdateControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 use App\Enum\Permissions;
 use App\Enum\Roles;
 use App\Models\Role;
+use App\Services\ImpersonationService;
 
 it('updates the permission set of a role and redirects back with a success flash', function(): void {
     actingAsSuperUser();
@@ -51,4 +52,115 @@ it('rejects permission names that do not exist', function(): void {
     $this->put(route('roles-permissions.update', ['role' => Roles::VIEWER->value]), [
         'permissions' => ['made_up_permission'],
     ])->assertSessionHasErrors(['permissions.0']);
+});
+
+/*
+ * `can:manage_roles` responde "pode mexer em cargo?", nunca "pode mexer NESTE
+ * cargo, com ESTAS permissões?". Como é esta mesma tela que distribui
+ * `manage_roles`, proteger só pela matriz seria proteger com a chave dentro da
+ * fechadura.
+ */
+
+it('forbids an admin from editing their own role', function(): void {
+    // O seeder tira impersonate_users do ADMIN de propósito. Com manage_roles na
+    // mão, ele abria esta tela e marcava a caixa no próprio cargo.
+    actingAsUserWithRole(Roles::ADMIN);
+
+    $this->put(route('roles-permissions.update', ['role' => Roles::ADMIN->value]), [
+        'permissions' => [
+            Permissions::MANAGE_USERS->value,
+            Permissions::IMPERSONATE_USERS->value,
+        ],
+    ])->assertForbidden();
+
+    $admin = Role::query()->where('name', Roles::ADMIN->value)->firstOrFail();
+
+    expect($admin->permissions()->pluck('name')->all())
+        ->not->toContain(Permissions::IMPERSONATE_USERS->value);
+});
+
+it('forbids an admin from editing the super user role', function(): void {
+    actingAsUserWithRole(Roles::ADMIN);
+
+    $this->put(route('roles-permissions.update', ['role' => Roles::SUPER_USER->value]), [
+        'permissions' => [],
+    ])->assertForbidden();
+
+    $superUser = Role::query()->where('name', Roles::SUPER_USER->value)->firstOrFail();
+
+    expect($superUser->permissions()->count())->toBe(count(Permissions::cases()));
+});
+
+it('forbids granting a permission the actor does not have', function(): void {
+    actingAsUserWithRole(Roles::ADMIN);
+
+    $this->put(route('roles-permissions.update', ['role' => Roles::MANAGER->value]), [
+        'permissions' => [Permissions::IMPERSONATE_USERS->value],
+    ])->assertForbidden();
+
+    $manager = Role::query()->where('name', Roles::MANAGER->value)->firstOrFail();
+
+    expect($manager->permissions()->pluck('name')->all())
+        ->not->toContain(Permissions::IMPERSONATE_USERS->value);
+});
+
+it('allows an admin to edit a lower role with permissions they hold', function(): void {
+    actingAsUserWithRole(Roles::ADMIN);
+
+    $this->put(route('roles-permissions.update', ['role' => Roles::MANAGER->value]), [
+        'permissions' => [Permissions::MANAGE_USERS->value],
+    ])->assertRedirect()->assertSessionHas('success');
+
+    $manager = Role::query()->where('name', Roles::MANAGER->value)->firstOrFail();
+
+    expect($manager->permissions()->pluck('name')->all())
+        ->toBe([Permissions::MANAGE_USERS->value]);
+});
+
+it('forbids a super user from removing manage_roles from their own role', function(): void {
+    // Sem esta trava, um "desmarcar tudo" no próprio cargo trancaria a operação
+    // fora do editor, com saída só por shell no servidor.
+    actingAsSuperUser();
+
+    $this->put(route('roles-permissions.update', ['role' => Roles::SUPER_USER->value]), [
+        'permissions' => [Permissions::MANAGE_USERS->value],
+    ])->assertForbidden();
+
+    $superUser = Role::query()->where('name', Roles::SUPER_USER->value)->firstOrFail();
+
+    expect($superUser->permissions()->pluck('name')->all())
+        ->toContain(Permissions::MANAGE_ROLES->value);
+});
+
+it('allows a super user to trim their own role while keeping manage_roles', function(): void {
+    actingAsSuperUser();
+
+    $this->put(route('roles-permissions.update', ['role' => Roles::SUPER_USER->value]), [
+        'permissions' => [
+            Permissions::MANAGE_ROLES->value,
+            Permissions::MANAGE_USERS->value,
+        ],
+    ])->assertRedirect()->assertSessionHas('success');
+
+    $superUser = Role::query()->where('name', Roles::SUPER_USER->value)->firstOrFail();
+
+    expect($superUser->permissions()->pluck('name')->sort()->values()->all())
+        ->toBe([Permissions::MANAGE_ROLES->value, Permissions::MANAGE_USERS->value]);
+});
+
+it('reads the ceiling from the impersonator, not from the persona', function(): void {
+    // O gerente veste o administrador: a permissão de abrir a tela vem da
+    // persona, mas o que ele pode conceder continua sendo o que ELE tem.
+    $manager = actingAsUserWithRole(Roles::MANAGER);
+    $persona = userWithRole(Roles::ADMIN);
+
+    app(ImpersonationService::class)->start($manager, $persona);
+
+    $this->put(route('roles-permissions.update', ['role' => Roles::VIEWER->value]), [
+        'permissions' => [Permissions::MANAGE_ROLES->value],
+    ])->assertForbidden();
+
+    $viewer = Role::query()->where('name', Roles::VIEWER->value)->firstOrFail();
+
+    expect($viewer->permissions()->count())->toBe(0);
 });

--- a/tests/Feature/Policies/UserPolicyCeilingTest.php
+++ b/tests/Feature/Policies/UserPolicyCeilingTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Enum\Permissions;
+use App\Enum\Roles;
+use App\Models\Role;
+
+/*
+ * Teto de autoridade do RBAC: `manage_users` sozinho não basta — o alvo precisa
+ * ter prioridade ESTRITAMENTE menor que a do ator real. Sem isso o gerente (70)
+ * excluía o administrador (90), e dois administradores eram pares agindo um
+ * sobre o outro (troca de e-mail e senha = tomada de conta).
+ */
+
+// region Alvo de prioridade IGUAL
+
+it('forbids an admin from updating another admin', function(): void {
+    actingAsUserWithRole(Roles::ADMIN);
+    $target = userWithRole(Roles::ADMIN);
+
+    $this->put(route('users.update', $target), [
+        'name'  => 'Sequestrado',
+        'email' => 'sequestrado@example.com',
+    ])->assertForbidden();
+
+    $this->assertDatabaseMissing('users', ['id' => $target->id, 'name' => 'Sequestrado']);
+});
+
+it('forbids an admin from deleting another admin', function(): void {
+    actingAsUserWithRole(Roles::ADMIN);
+    $target = userWithRole(Roles::ADMIN);
+
+    $this->delete(route('users.destroy', $target))->assertForbidden();
+
+    $this->assertDatabaseHas('users', ['id' => $target->id]);
+});
+
+it('forbids an admin from deactivating another admin', function(): void {
+    actingAsUserWithRole(Roles::ADMIN);
+    $target = userWithRole(Roles::ADMIN);
+
+    $this->patch(route('users.toggle-active', $target))->assertForbidden();
+
+    $this->assertDatabaseHas('users', ['id' => $target->id, 'is_active' => true]);
+});
+
+// endregion
+// region Alvo de prioridade MAIOR
+
+it('forbids a manager from updating an admin', function(): void {
+    actingAsUserWithRole(Roles::MANAGER);
+    $target = userWithRole(Roles::ADMIN);
+
+    $this->put(route('users.update', $target), [
+        'name'  => 'Sequestrado',
+        'email' => 'sequestrado@example.com',
+    ])->assertForbidden();
+
+    $this->assertDatabaseMissing('users', ['id' => $target->id, 'name' => 'Sequestrado']);
+});
+
+it('forbids a manager from deleting an admin', function(): void {
+    actingAsUserWithRole(Roles::MANAGER);
+    $target = userWithRole(Roles::ADMIN);
+
+    $this->delete(route('users.destroy', $target))->assertForbidden();
+
+    $this->assertDatabaseHas('users', ['id' => $target->id]);
+});
+
+it('forbids a manager from deactivating an admin', function(): void {
+    actingAsUserWithRole(Roles::MANAGER);
+    $target = userWithRole(Roles::ADMIN);
+
+    $this->patch(route('users.toggle-active', $target))->assertForbidden();
+
+    $this->assertDatabaseHas('users', ['id' => $target->id, 'is_active' => true]);
+});
+
+// endregion
+// region O teto não trava o caminho legítimo
+
+it('allows an admin to delete a manager', function(): void {
+    actingAsUserWithRole(Roles::ADMIN);
+    $target = userWithRole(Roles::MANAGER);
+
+    $this->delete(route('users.destroy', $target))
+        ->assertRedirect(route('users.index'))
+        ->assertSessionHas('success');
+
+    $this->assertDatabaseMissing('users', ['id' => $target->id]);
+});
+
+it('allows a super user to delete another super user', function(): void {
+    actingAsSuperUser();
+    $target = userWithRole(Roles::SUPER_USER);
+
+    $this->delete(route('users.destroy', $target))
+        ->assertRedirect(route('users.index'))
+        ->assertSessionHas('success');
+
+    $this->assertDatabaseMissing('users', ['id' => $target->id]);
+});
+
+it('keeps reading the permission matrix open, including for users above the actor', function(): void {
+    // Só a MUTAÇÃO ganha teto: quem administra usuários precisa enxergar o que
+    // cada conta pode fazer, inclusive contas acima da sua.
+    actingAsUserWithRole(Roles::ADMIN);
+    $target = userWithRole(Roles::SUPER_USER);
+
+    $this->get(route('users.permissions.show', $target))->assertOk();
+});
+
+// endregion
+// region Mutação de permissões individuais
+
+it('forbids an admin from granting themselves the permission the seeder denies', function(): void {
+    // O PermissionRoleSeeder tira impersonate_users do ADMIN de propósito. Sem
+    // o alvo na policy, o ADMIN se auto-concedia a permissão pelo sync.
+    $admin = actingAsUserWithRole(Roles::ADMIN);
+
+    $this->post(route('user.sync-permissions', $admin), [
+        'permissions' => [Permissions::IMPERSONATE_USERS->value],
+    ])->assertForbidden();
+
+    expect($admin->fresh()?->hasPermissionTo(Permissions::IMPERSONATE_USERS))->toBeFalse();
+});
+
+it('forbids an admin from mutating the permissions of a super user', function(): void {
+    actingAsUserWithRole(Roles::ADMIN);
+    $target = userWithRole(Roles::SUPER_USER);
+    $target->givePermissionTo(Permissions::IMPERSONATE_USERS);
+
+    $this->post(route('user.sync-permissions', $target), ['permissions' => []])
+        ->assertForbidden();
+
+    $this->delete(route('users.permissions.revoke', [
+        'user'       => $target,
+        'permission' => Permissions::IMPERSONATE_USERS->value,
+    ]))->assertForbidden();
+
+    expect($target->fresh()?->permissions()->count())->toBe(1);
+});
+
+it('allows an admin to mutate the permissions of a manager', function(): void {
+    actingAsUserWithRole(Roles::ADMIN);
+    $target = userWithRole(Roles::MANAGER);
+
+    $this->post(route('user.sync-permissions', $target), [
+        'permissions' => [Permissions::MANAGE_PERMISSIONS->value],
+    ])->assertRedirect()->assertSessionHas('success');
+
+    expect($target->fresh()?->permissions()->pluck('name')->all())
+        ->toBe([Permissions::MANAGE_PERMISSIONS->value]);
+});
+
+// endregion
+// region Cargo do alvo (assign / revoke)
+
+it('forbids a manager from demoting an admin through assign-role', function(): void {
+    actingAsUserWithRole(Roles::MANAGER);
+    $target      = userWithRole(Roles::ADMIN);
+    $adminRoleId = $target->role_id;
+
+    // `viewer` está entre os cargos que o gerente pode atribuir — o que a
+    // validação antiga olhava. O que faltava era olhar o cargo ATUAL do alvo.
+    $this->post(route('user.assign-role', $target), ['role' => Roles::VIEWER->value])
+        ->assertSessionHasErrors(['error']);
+
+    $this->assertDatabaseHas('users', ['id' => $target->id, 'role_id' => $adminRoleId]);
+});
+
+it('forbids a manager from demoting an admin through revoke-role', function(): void {
+    actingAsUserWithRole(Roles::MANAGER);
+    $target      = userWithRole(Roles::ADMIN);
+    $adminRoleId = $target->role_id;
+
+    $this->delete(route('user.revoke-role', $target))
+        ->assertSessionHasErrors(['error']);
+
+    $this->assertDatabaseHas('users', ['id' => $target->id, 'role_id' => $adminRoleId]);
+});
+
+it('allows a manager to demote a viewer', function(): void {
+    actingAsUserWithRole(Roles::MANAGER);
+    $target = userWithRole(Roles::VIEWER);
+
+    $this->delete(route('user.revoke-role', $target))
+        ->assertRedirect()
+        ->assertSessionHas('success');
+
+    $visitorRoleId = Role::query()->where('name', Roles::VISITOR->value)->firstOrFail()->id;
+
+    $this->assertDatabaseHas('users', ['id' => $target->id, 'role_id' => $visitorRoleId]);
+});
+
+// endregion
+// region Impersonação não é escada
+
+it('does not lend the persona authority to the impersonator', function(): void {
+    // O gerente veste o administrador — mas o teto continua sendo o do humano
+    // por trás da sessão, senão impersonar seria o caminho para subir.
+    $manager = actingAsUserWithRole(Roles::MANAGER);
+    $manager->givePermissionTo(Permissions::IMPERSONATE_USERS, ['can_impersonate_any' => true]);
+
+    $persona = userWithRole(Roles::ADMIN);
+    $target  = userWithRole(Roles::MANAGER);
+
+    $this->post(route('users.impersonate', $persona))->assertRedirect(route('dashboard'));
+
+    $this->delete(route('users.destroy', $target))->assertForbidden();
+
+    $this->assertDatabaseHas('users', ['id' => $target->id]);
+});
+
+it('lets a real admin do what the impersonating manager could not', function(): void {
+    // Contraprova do teste acima: o mesmo alvo, o mesmo cargo de ator — só que
+    // sem impersonação no meio.
+    actingAsUserWithRole(Roles::ADMIN);
+    $target = userWithRole(Roles::MANAGER);
+
+    $this->delete(route('users.destroy', $target))
+        ->assertRedirect(route('users.index'));
+
+    $this->assertDatabaseMissing('users', ['id' => $target->id]);
+});
+
+it('forbids the impersonator from deleting their own account through the persona', function(): void {
+    $manager = actingAsUserWithRole(Roles::MANAGER);
+    $manager->givePermissionTo(Permissions::IMPERSONATE_USERS, ['can_impersonate_any' => true]);
+
+    $persona = userWithRole(Roles::ADMIN);
+
+    $this->post(route('users.impersonate', $persona))->assertRedirect(route('dashboard'));
+
+    $this->delete(route('users.destroy', $manager))->assertForbidden();
+
+    $this->assertDatabaseHas('users', ['id' => $manager->id]);
+});
+
+// endregion

--- a/tests/Feature/User/EditControllerTest.php
+++ b/tests/Feature/User/EditControllerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types = 1);
 
 use App\Enum\Roles;
+use App\Models\Role;
 use Inertia\Testing\AssertableInertia as Assert;
 
 it('renders the edit form with the target user data', function(): void {
@@ -18,16 +19,35 @@ it('renders the edit form with the target user data', function(): void {
 });
 
 it('includes the current role of the edited user even when not assignable', function(): void {
-    // MANAGER (70) não pode atribuir ADMIN (90), mas o cargo atual do usuário
-    // editado precisa aparecer selecionado no formulário.
-    actingAsUserWithRole(Roles::MANAGER);
-    $target = userWithRole(Roles::ADMIN);
+    // Um cargo legado fora do allowlist do enum não é atribuível por ninguém,
+    // nem pelo SUPER_USER — mas o cargo atual do usuário editado precisa
+    // aparecer selecionado no formulário.
+    actingAsSuperUser();
+
+    $legacyRole = Role::create([
+        'name'     => 'legacy_role_not_allowed',
+        'label'    => 'Legado (fora do allowlist)',
+        'priority' => 1,
+    ]);
+
+    $target = guestUser();
+    $target->update(['role_id' => $legacyRole->id]);
 
     $this->get(route('users.edit', $target))
         ->assertOk()
         ->assertInertia(fn(Assert $page) => $page
             ->component('users/edit')
-            ->has('roles', 3));
+            // Os 5 cargos do enum, atribuíveis pelo SUPER_USER, mais o legado.
+            ->has('roles', 6)
+            ->where('roles.5.name', $legacyRole->name));
+});
+
+it('forbids a manager from opening the edit form of an admin', function(): void {
+    // MANAGER (70) tem manage_users, mas não supera ADMIN (90).
+    actingAsUserWithRole(Roles::MANAGER);
+    $target = userWithRole(Roles::ADMIN);
+
+    $this->get(route('users.edit', $target))->assertForbidden();
 });
 
 it('forbids a user without manage_users', function(): void {


### PR DESCRIPTION
Fecha #35. Harvest reversa do `spinmax` (origem do boilerplate) — PR A de cinco. Só mecanismo, nenhuma regra de negócio do cliente veio junto.

Todos os quatro achados foram reproduzidos contra o código atual antes da correção. Os testes novos foram rodados contra o código antigo: **17 dos 29 falham sem o fix**, e os que passam são os controles de "o caminho legítimo continua aberto".

## O que estava aberto

| # | Onde | Quem escala |
|---|---|---|
| 1 | `UserPolicy::update/delete/toggleActive` — única guarda era `!$model->hasRole('super_user')` | `manager` (70) exclui `admin` (90); `admin` troca e-mail e senha de outro `admin` |
| 2 | `UserPolicy::managePermissions(User $user)` — um parâmetro só; o PHP descarta o alvo que os call sites passam | qualquer `manage_permissions` muta qualquer conta, **inclusive a própria** — `admin` se auto-concede `impersonate_users` pelo `user.sync-permissions` |
| 3 | `PermissionRole/UpdateController` — do FormRequest direto ao `sync()` | `admin` tem `manage_roles`, abre `/permissions/roles`, marca a caixa no próprio cargo e anula a exclusão do seeder |
| 4 | `AssignRoleController` / `RevokeRoleController` — comparam o cargo **novo** com o do ator, nunca leem `$user->role` | `manager` rebaixa `admin` para `viewer`, ou o joga em `visitor` pelo revoke |

O 2 é o mais perverso: `GrantPermissionRequest::authorize()` exige `SUPER_USER`, o que dá a impressão de que a mutação está fechada. Mas `SyncPermissionsRequest::authorize()` pede só `manage_users`, e é por ali que o `admin` passa.

## O que mudou

- **`UserPolicy`** — `outranks()` exige alvo de prioridade **estritamente menor**; `super_user` segue passando por cima de tudo, inclusive de outro `super_user`.
- **`effectiveActor()`** — o teto é do humano por trás da sessão, não da persona. A permissão continua sendo lida na persona (impersonar precisa reproduzir o que aquele usuário consegue fazer), mas `canImpersonateAny()` ignora prioridade: sem isso, vestir um cargo mais alto viraria escada. Mesma leitura que `RoleFilterService` e `AssignRoleController` já faziam.
- **Leitura ≠ mutação** — `managePermissions` (sem teto) continua servindo `users.permissions.show`; grant/revoke/sync passam a `mutatePermissions($user, $model)`.
- **`assignRole($user, $model)`** — consumido via `Gate::denies` em assign/revoke, mantendo o canal de erro inline desses controllers (`withErrors`) em vez de trocar por 403.
- **`ensureActorMayEdit()`** — prioridade estritamente menor + `array_diff` contra a superfície do ator + trava anti-lockout do `super_user`.

`Role::getPriority()` já existia. **Nenhuma migration.**

### Duas divergências deliberadas da referência

1. O `spinmax` lê as permissões do ator só pelo cargo (`$actor->role?->permissions()`). Aqui uso `getAllPermissions()`, que soma cargo + permissões individuais — é a superfície real do ator neste boilerplate, que tem concessão direta por usuário.
2. Em assign/revoke usei `Gate::denies` + `withErrors` em vez de `authorize` + 403, para não regredir a UX desses dois fluxos, que hoje respondem com erro inline.

## Testes

`tests/Feature/Policies/UserPolicyCeilingTest.php` (18) e 7 casos novos em `PermissionRole/UpdateControllerTest.php`:

- ator × alvo de prioridade **igual** → 403 (update, delete, toggleActive)
- `manager` sobre `admin` → 403 nos três verbos
- `admin` marcando `impersonate_users` no próprio cargo → 403
- `admin` concedendo a um cargo menor permissão que ele não tem → 403
- `super_user` tirando `manage_roles` do próprio cargo → 403
- impersonador não herda o teto da persona, **com contraprova**: o mesmo alvo, o mesmo cargo de ator, sem impersonação no meio → passa
- controles: `admin` exclui `manager`; `super_user` exclui `super_user`; leitura da matriz segue aberta inclusive para contas acima do ator

### Teste existente que mudou

`EditControllerTest` cobria "o cargo atual aparece mesmo quando não é atribuível" com **gerente editando administrador** — agora proibido. O caso migrou para um cargo legado fora do allowlist do enum (mesmo shape do `AssignRoleAllowlistTest`), e o par gerente×administrador virou teste de negação. A cobertura não encolheu.

## Follow-up conhecido (não é regressão silenciosa)

O front monta os botões da lista de usuários só com permissões globais (`use-user-permissions`), sem flag por linha. Com o teto, `admin` e `manager` passam a ver **Editar/Excluir** em linhas que agora respondem 403. Backend está correto; a UX precisa de `can` por usuário no `UserResource`. Fica para issue separada — mexer nisso aqui misturaria o contrato de shared props com um PR de segurança.

## Gates

- `composer ci:check` — Pint, Rector, larastan, 276 testes ✅
- `corepack pnpm ci:check` — ESLint, Prettier, tsc, Vitest, build ✅ (sem mudança de frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)