### PR TITLE
[38] fix(painel): cinco bugs isolados do painel de usuários

### DIFF
--- a/app/Http/Controllers/User/UpdateController.php
+++ b/app/Http/Controllers/User/UpdateController.php
@@ -28,6 +28,19 @@ final class UpdateController extends Controller
 
         $data = $request->validated();
 
+        // Select de cargo vazio significa "não mexer no cargo", não "apagar o
+        // cargo". O ConvertEmptyStringsToNull transforma `role_id=''` em null, a
+        // regra é `nullable`, e o bloco de validação de cargo abaixo é guardado
+        // por isset() — que é false para null. O resultado era o pior dos dois
+        // mundos: o null passava para o update e apagava o cargo, mas o flush de
+        // `user:{id}:permissions` (que mora dentro daquele bloco) era pulado.
+        // Como o cache é rememberForever, a pessoa perdia o cargo no banco e
+        // ficava com as permissões dele para sempre. Para remover cargo existe a
+        // rota `user.revoke-role`.
+        if (array_key_exists('role_id', $data) && $data['role_id'] === null) {
+            unset($data['role_id']);
+        }
+
         // Se estiver impersonando, usa o usuário original (impersonador) para validações
         $effectiveUser = $this->impersonationService->getOriginalUser() ?? $request->user();
         $effectiveUser->load('role');

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -5,11 +5,20 @@ namespace App\Http\Middleware;
 use App\Services\ImpersonationService;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Inertia\Middleware;
 use Tighten\Ziggy\Ziggy;
 
 class HandleInertiaRequests extends Middleware
 {
+    /**
+     * Campos do usuário autenticado publicados em toda página. Mexer aqui exige
+     * atualizar o tipo `AuthUser` em resources/js/types no mesmo commit.
+     *
+     * @var list<string>
+     */
+    private const SHARED_USER_FIELDS = ['id', 'name', 'email', 'email_verified_at'];
+
     protected $rootView = 'app';
 
     public function version(Request $request): ?string
@@ -39,7 +48,12 @@ class HandleInertiaRequests extends Middleware
             'name'  => config('app.name'),
             'quote' => ['message' => trim($message), 'author' => trim($author)],
             'auth'  => [
-                'user'          => $user,
+                // Só o que o front realmente lê. `$hidden` do model esconde
+                // apenas password e remember_token, então compartilhar o model
+                // inteiro mandava cpf_cnpj, phone, mobile e user_notes em TODA
+                // navegação do painel, para qualquer tela. O espelho deste shape
+                // é o tipo `AuthUser` em resources/js/types.
+                'user'          => $user ? Arr::only($user->toArray(), self::SHARED_USER_FIELDS) : null,
                 'permissions'   => $permissions,
                 'roles'         => $roles,
                 'impersonating' => [

--- a/resources/js/components/user-info.tsx
+++ b/resources/js/components/user-info.tsx
@@ -1,8 +1,8 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { useInitials } from '@/hooks/use-initials';
-import { type User } from '@/types';
+import { type AuthUser } from '@/types';
 
-export function UserInfo({ user, showEmail = false }: { user: User; showEmail?: boolean }) {
+export function UserInfo({ user, showEmail = false }: { user: AuthUser; showEmail?: boolean }) {
     const getInitials = useInitials();
 
     return (

--- a/resources/js/components/user-menu-content.tsx
+++ b/resources/js/components/user-menu-content.tsx
@@ -1,12 +1,12 @@
 import { DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
 import { UserInfo } from '@/components/user-info';
 import { useMobileNavigation } from '@/hooks/use-mobile-navigation';
-import { type User } from '@/types';
+import { type AuthUser } from '@/types';
 import { Link } from '@inertiajs/react';
 import { LogOut, Settings } from 'lucide-react';
 
 interface UserMenuContentProps {
-    user: User;
+    user: AuthUser;
 }
 
 export function UserMenuContent({ user }: UserMenuContentProps) {

--- a/resources/js/components/users/user-table-row.tsx
+++ b/resources/js/components/users/user-table-row.tsx
@@ -59,7 +59,7 @@ export const UserTableRow = React.memo(
                         ) : (
                             <span className="text-muted-foreground/60 text-xs">-</span>
                         )}
-                        {user.custom_permissions_count && user.custom_permissions_count > 0 && (
+                        {(user.custom_permissions_count ?? 0) > 0 && (
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <Badge

--- a/resources/js/hooks/use-flash-messages.tsx
+++ b/resources/js/hooks/use-flash-messages.tsx
@@ -34,7 +34,14 @@ if (typeof window !== 'undefined' && !(window as WindowWithFlashCleanup).__flash
 }
 
 export function useFlashMessages() {
-    const { flash, url } = usePage<{ flash?: FlashMessages; url?: string }>().props;
+    // `url` vive no objeto de página do Inertia, não entre as props — e o
+    // `share()` não publica nenhuma chave `url`. Lido de `props`, era sempre
+    // `undefined`, e o reset de dedupe ao trocar de página nunca acontecia:
+    // a mesma mensagem em outra tela ficava engolida pela chave global até o
+    // intervalo de limpeza de 10s passar.
+    const page = usePage<{ flash?: FlashMessages }>();
+    const { flash } = page.props;
+    const url = page.url;
     const componentRef = useRef<{ lastFlash: string; lastUrl: string }>({
         lastFlash: '',
         lastUrl: '',

--- a/resources/js/hooks/use-permissions.ts
+++ b/resources/js/hooks/use-permissions.ts
@@ -8,21 +8,21 @@ export function usePermissions() {
 
     if (!user) return { hasPermission: () => false, hasRole: () => false };
 
-    // Extrair nomes de permissions (pode ser array de strings ou objetos Permission)
+    // `auth.permissions` e `auth.roles` são a fonte única — o `share()` do
+    // HandleInertiaRequests sempre publica as duas. O fallback que existia aqui
+    // lia `user.permissions` e `user.role`, campos que o `auth.user` nunca
+    // carregou (as relations não são eager-loaded no share), então só devolvia
+    // lista vazia: era um segundo canal com outro shape, e sem dados.
+
+    // Aceita array de nomes (string) ou objetos Permission/Role
     const authPermissions = auth?.permissions || [];
     const permissionsNames: string[] = authPermissions.map((p: string | Permission) => (typeof p === 'string' ? p : p.name));
 
-    // Extrair nomes de roles (pode ser array de strings ou objetos Role)
     const authRoles = auth?.roles || [];
     const rolesNames: string[] = authRoles.map((r: string | Role) => (typeof r === 'string' ? r : r.name));
 
-    // Fallback: se não estiver no auth, tentar do user
-    const userPermissionsNames = permissionsNames.length > 0 ? permissionsNames : (user.permissions || []).map((p: Permission) => p.name);
-
-    const userRolesNames = rolesNames.length > 0 ? rolesNames : user.role ? [user.role.name] : [];
-
-    const userRolesSet = new Set(userRolesNames);
-    const userPermissionsSet = new Set(userPermissionsNames);
+    const userRolesSet = new Set(rolesNames);
+    const userPermissionsSet = new Set(permissionsNames);
 
     const hasRole = (role: string) => userRolesSet.has(role);
     const hasPermission = (permission: string) => userPermissionsSet.has(permission);

--- a/resources/js/hooks/users/use-user-permissions.ts
+++ b/resources/js/hooks/users/use-user-permissions.ts
@@ -54,8 +54,19 @@ export function useUserPermissions() {
         [hasPermission, auth.user.id],
     );
 
+    /**
+     * Lê `manage_permissions`, não `manage_users`. São permissões diferentes no
+     * servidor desde sempre: o item "Permissões" da linha cai no
+     * `ShowUserPermissionsController`, que autoriza por
+     * `UserPolicy::managePermissions` → `manage_permissions`. O MANAGER é
+     * semeado com a primeira e sem a segunda, então o item aparecia para ele e
+     * devolvia 403 em todos os cliques.
+     *
+     * Quem responde "consegue mexer neste usuário?" é o `canEdit`; este aqui
+     * responde só "consegue mexer no acesso AVULSO de alguém?".
+     */
     const canManagePermissions = useCallback(() => {
-        return hasPermission('manage_users');
+        return hasPermission('manage_permissions');
     }, [hasPermission]);
 
     const canAssignRoles = useCallback(() => {

--- a/resources/js/test/components/users/user-table-row.test.tsx
+++ b/resources/js/test/components/users/user-table-row.test.tsx
@@ -1,0 +1,70 @@
+import { UserTableRow } from '@/components/users/user-table-row';
+import type { User } from '@/types';
+import { Table, Theme } from '@radix-ui/themes';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@inertiajs/react', () => ({
+    Link: ({ children }: { children: ReactNode }) => <a href="#">{children}</a>,
+}));
+
+function makeUser(overrides: Partial<User> = {}): User {
+    return {
+        id: 1,
+        name: 'Ana Souza',
+        email: 'ana@example.com',
+        is_active: true,
+        email_verified_at: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        role: { id: 3, name: 'manager', label: 'Gerente' },
+        ...overrides,
+    } as User;
+}
+
+function renderRow(user: User) {
+    return render(
+        <Theme>
+            <Table.Root>
+                <Table.Body>
+                    <UserTableRow
+                        user={user}
+                        index={0}
+                        onView={vi.fn()}
+                        canDelete={() => false}
+                        canEdit={false}
+                        canImpersonate={() => false}
+                        canManagePermissions={false}
+                        canAssignRoles={false}
+                        getUserInitials={(name: string) => name.charAt(0)}
+                    />
+                </Table.Body>
+            </Table.Root>
+        </Theme>,
+    );
+}
+
+describe('UserTableRow', () => {
+    // `count && count > 0 && (…)` avalia para `0` quando a contagem é zero — e o
+    // React renderiza o zero. Era o caso comum: quase todo usuário tem zero
+    // permissões individuais.
+    it('renders no stray zero when the user has no individual permissions', () => {
+        renderRow(makeUser({ custom_permissions_count: 0 }));
+
+        expect(screen.getByText('Gerente')).toBeInTheDocument();
+        expect(screen.queryByText('0')).not.toBeInTheDocument();
+    });
+
+    it('renders nothing extra when the count is absent', () => {
+        renderRow(makeUser());
+
+        expect(screen.queryByText('0')).not.toBeInTheDocument();
+    });
+
+    it('still shows the badge when there are individual permissions', () => {
+        renderRow(makeUser({ custom_permissions_count: 2 }));
+
+        expect(screen.getByText('2')).toBeInTheDocument();
+    });
+});

--- a/resources/js/test/hooks/use-flash-messages.test.ts
+++ b/resources/js/test/hooks/use-flash-messages.test.ts
@@ -1,0 +1,80 @@
+import { useFlashMessages } from '@/hooks/use-flash-messages';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@inertiajs/react', () => ({
+    usePage: vi.fn(),
+}));
+
+vi.mock('react-hot-toast', () => ({
+    default: Object.assign(vi.fn(), {
+        success: vi.fn(),
+        error: vi.fn(),
+    }),
+}));
+
+import { usePage } from '@inertiajs/react';
+import toast from 'react-hot-toast';
+
+const mockedToast = toast as unknown as {
+    success: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+};
+
+/**
+ * O Inertia expõe `url` no objeto de página, não entre as props — e o `share()`
+ * não publica nenhuma chave `url`. Lendo de `props`, o valor era sempre
+ * undefined e o reset de dedupe por página nunca disparava.
+ */
+function mockPage(url: string, flash: Record<string, string> | undefined) {
+    (usePage as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        url,
+        props: { flash },
+    });
+}
+
+describe('useFlashMessages', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('shows a flash message once', () => {
+        mockPage('/users', { success: 'Usuário criado' });
+
+        renderHook(() => useFlashMessages());
+
+        expect(mockedToast.success).toHaveBeenCalledTimes(1);
+        expect(mockedToast.success).toHaveBeenCalledWith('Usuário criado', expect.anything());
+    });
+
+    it('does not repeat the same message on a re-render of the same page', () => {
+        mockPage('/users', { success: 'Repetida na mesma página' });
+
+        const { rerender } = renderHook(() => useFlashMessages());
+        rerender();
+
+        expect(mockedToast.success).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows the same text again after navigating to another page', () => {
+        // Antes do fix, `currentUrl` era sempre '' e a chave global de dedupe
+        // (`${url}::${flash}`) colidia entre telas: a segunda ocorrência era
+        // engolida até o intervalo de limpeza de 10s passar.
+        mockPage('/users', { success: 'Operação concluída' });
+        renderHook(() => useFlashMessages());
+
+        mockPage('/permissions/roles', { success: 'Operação concluída' });
+        renderHook(() => useFlashMessages());
+
+        expect(mockedToast.success).toHaveBeenCalledTimes(2);
+    });
+
+    it('stays quiet when there is no flash', () => {
+        mockPage('/dashboard', undefined);
+
+        renderHook(() => useFlashMessages());
+
+        expect(mockedToast.success).not.toHaveBeenCalled();
+        expect(mockedToast.error).not.toHaveBeenCalled();
+    });
+});

--- a/resources/js/test/hooks/use-permissions.test.ts
+++ b/resources/js/test/hooks/use-permissions.test.ts
@@ -37,20 +37,15 @@ describe('usePermissions Hook', () => {
         expect(hasRole('admin')).toBe(false);
     });
 
-    it('correctly checks user permissions', () => {
+    // O `share()` publica listas de NOMES em `auth.permissions` e `auth.roles` —
+    // é este o contrato. Cargo e permissões nunca vieram dentro de `auth.user`.
+    it('correctly checks user permissions from the shared name lists', () => {
         (usePage as any).mockReturnValue({
             props: {
                 auth: {
-                    user: {
-                        permissions: [
-                            { name: 'create-users', label: 'Create Users' },
-                            { name: 'edit-users', label: 'Edit Users' },
-                        ],
-                    },
-                    roles: [
-                        { name: 'admin', label: 'Administrator' },
-                        { name: 'editor', label: 'Editor' },
-                    ],
+                    user: { id: 1, name: 'Ana', email: 'ana@example.com', email_verified_at: null },
+                    permissions: ['create-users', 'edit-users'],
+                    roles: ['admin', 'editor'],
                 },
             },
         });
@@ -63,6 +58,31 @@ describe('usePermissions Hook', () => {
 
         expect(hasRole('admin')).toBe(true);
         expect(hasRole('editor')).toBe(true);
+        expect(hasRole('viewer')).toBe(false);
+    });
+
+    it('also accepts the object form of permissions and roles', () => {
+        (usePage as any).mockReturnValue({
+            props: {
+                auth: {
+                    user: { id: 1, name: 'Ana', email: 'ana@example.com', email_verified_at: null },
+                    permissions: [
+                        { name: 'create-users', label: 'Create Users' },
+                        { name: 'edit-users', label: 'Edit Users' },
+                    ],
+                    roles: [
+                        { name: 'admin', label: 'Administrator' },
+                        { name: 'editor', label: 'Editor' },
+                    ],
+                },
+            },
+        });
+
+        const { hasPermission, hasRole } = usePermissions();
+
+        expect(hasPermission('create-users')).toBe(true);
+        expect(hasPermission('delete-users')).toBe(false);
+        expect(hasRole('admin')).toBe(true);
         expect(hasRole('viewer')).toBe(false);
     });
 

--- a/resources/js/test/hooks/use-user-permissions.test.ts
+++ b/resources/js/test/hooks/use-user-permissions.test.ts
@@ -1,0 +1,53 @@
+import { useUserPermissions } from '@/hooks/users/use-user-permissions';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@inertiajs/react', () => ({
+    usePage: vi.fn(),
+}));
+
+import { usePage } from '@inertiajs/react';
+
+function mockAuth(permissions: string[], roles: string[] = []) {
+    (usePage as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        props: {
+            auth: { user: { id: 1 }, permissions, roles },
+        },
+    });
+}
+
+function permissionsOf(permissions: string[], roles: string[] = []) {
+    mockAuth(permissions, roles);
+
+    return renderHook(() => useUserPermissions()).result.current;
+}
+
+describe('useUserPermissions', () => {
+    describe('canManagePermissions', () => {
+        // O item "Permissões" da linha cai no ShowUserPermissionsController, que
+        // autoriza por `manage_permissions`. Ler `manage_users` aqui mostrava o
+        // item para o MANAGER (semeado com a primeira e sem a segunda) e
+        // garantia 403 em todos os cliques.
+        it('reads manage_permissions, the permission the backend actually checks', () => {
+            expect(permissionsOf(['manage_permissions']).canManagePermissions()).toBe(true);
+        });
+
+        it('stays closed for manage_users alone — the seeded MANAGER case', () => {
+            expect(permissionsOf(['manage_users', 'assign_roles']).canManagePermissions()).toBe(false);
+        });
+
+        it('stays closed with no permissions at all', () => {
+            expect(permissionsOf([]).canManagePermissions()).toBe(false);
+        });
+    });
+
+    describe('canEdit', () => {
+        it('keeps gating on manage_users', () => {
+            expect(permissionsOf(['manage_users']).canEdit()).toBe(true);
+        });
+
+        it('is not opened by manage_permissions', () => {
+            expect(permissionsOf(['manage_permissions']).canEdit()).toBe(false);
+        });
+    });
+});

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -2,8 +2,25 @@ import { LucideIcon } from 'lucide-react';
 import { ReactNode } from 'react';
 import type { Config } from 'ziggy-js';
 
+/**
+ * Usuário autenticado como ele chega em toda página, e nada além disso.
+ * Espelha `HandleInertiaRequests::SHARED_USER_FIELDS` — os dois mudam juntos.
+ *
+ * Cargo e permissões NÃO vêm por aqui: são `auth.roles` e `auth.permissions`.
+ * Para o usuário completo (cpf_cnpj, phone, mobile, user_notes) use o `User`
+ * que as páginas do módulo recebem via `UserResource`.
+ */
+export interface AuthUser {
+    id: number;
+    name: string;
+    email: string;
+    email_verified_at: string | null;
+    /** Nunca vem do servidor — só existe para o `<AvatarImage>`. */
+    avatar?: string;
+}
+
 export interface Auth {
-    user: User;
+    user: AuthUser;
     roles: string[] | Role[]; // Array de nomes (string) ou objetos Role
     permissions: string[] | Permission[]; // Array de nomes (string) ou objetos Permission
     impersonating?: {

--- a/tests/Feature/SharedPropsTest.php
+++ b/tests/Feature/SharedPropsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Enum\Permissions;
+use App\Enum\Roles;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/*
+ * `HandleInertiaRequests::share()` é a fonte única das props globais, e o que
+ * sai daqui viaja em TODA navegação do painel. O espelho deste shape são os
+ * tipos em resources/js/types — os dois mudam juntos.
+ */
+
+it('shares only the fields the front actually reads from the authenticated user', function(): void {
+    // O $hidden do model esconde só password e remember_token: compartilhar o
+    // model inteiro mandava cpf_cnpj, phone, mobile e user_notes em toda página.
+    $user = actingAsSuperUser();
+
+    $user->update([
+        'cpf_cnpj'   => '11144477735',
+        'phone'      => '(11) 3333-4444',
+        'mobile'     => '(11) 98888-7777',
+        'user_notes' => 'Anotação interna sobre esta pessoa.',
+    ]);
+
+    $this->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn(Assert $page) => $page
+            ->has('auth.user', 4)
+            ->where('auth.user.id', $user->id)
+            ->where('auth.user.name', $user->name)
+            ->where('auth.user.email', $user->email)
+            ->has('auth.user.email_verified_at')
+            ->missing('auth.user.cpf_cnpj')
+            ->missing('auth.user.phone')
+            ->missing('auth.user.mobile')
+            ->missing('auth.user.user_notes')
+            ->missing('auth.user.role_id')
+            ->missing('auth.user.password'));
+});
+
+it('keeps publishing roles and permissions on their own keys', function(): void {
+    // Cargo e permissões não vêm dentro de auth.user — o front lê auth.roles e
+    // auth.permissions. Estreitar o usuário não pode ter levado isso junto.
+    actingAsUserWithRole(Roles::MANAGER);
+
+    $this->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn(Assert $page) => $page
+            ->where('auth.roles', [Roles::MANAGER->value])
+            ->where('auth.permissions', [
+                Permissions::MANAGE_USERS->value,
+                Permissions::ASSIGN_ROLES->value,
+            ]));
+});

--- a/tests/Feature/User/UpdateControllerTest.php
+++ b/tests/Feature/User/UpdateControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types = 1);
 
+use App\Enum\Permissions;
 use App\Enum\Roles;
 use App\Models\Role;
 
@@ -87,6 +88,33 @@ it('rejects changing your own role', function(): void {
     ])->assertSessionHasErrors(['role_id']);
 
     $this->assertDatabaseMissing('users', ['id' => $superUser->id, 'role_id' => $adminRoleId]);
+});
+
+it('treats an empty role select as "leave the role alone"', function(): void {
+    // `role_id=''` vira null no ConvertEmptyStringsToNull e passa na regra
+    // `nullable`, mas o bloco que valida troca de cargo é guardado por isset() —
+    // false para null. O null ia para o update e apagava o cargo, enquanto o
+    // flush de `user:{id}:permissions`, que mora dentro daquele bloco, era
+    // pulado: banco sem cargo, cache rememberForever com as permissões dele.
+    actingAsSuperUser();
+    $target        = userWithRole(Roles::MANAGER);
+    $managerRoleId = $target->role_id;
+
+    // Aquece o cache, como qualquer navegação real do usuário faria.
+    expect($target->hasPermissionTo(Permissions::MANAGE_USERS))->toBeTrue();
+
+    $this->put(route('users.update', $target), [
+        'name'    => 'Nome Novo',
+        'email'   => $target->email,
+        'role_id' => '',
+    ])->assertRedirect(route('users.show', $target));
+
+    $fresh = $target->fresh();
+
+    expect($fresh?->name)->toBe('Nome Novo')
+        ->and($fresh?->role_id)->toBe($managerRoleId)
+        // Banco e cache continuam contando a mesma história.
+        ->and($fresh?->hasPermissionTo(Permissions::MANAGE_USERS))->toBeTrue();
 });
 
 it('forbids a manager from assigning a role above their own', function(): void {


### PR DESCRIPTION
Fecha #38. Harvest reversa do `spinmax` — PR B de cinco. Bugs independentes entre si; agrupados só porque são pequenos e do mesmo módulo. Cada um tem teste próprio, e os testes novos foram rodados contra o código antigo: **6 falham sem o fix**.

## 1. Botão de permissões checava a permissão errada

`use-user-permissions.ts:57` gateava em `manage_users`; o backend autoriza por `manage_permissions`. O MANAGER é semeado com a primeira e **sem** a segunda: via o item "Permissões" no menu da linha e tomava 403 em 100% dos cliques.

Escopo do gate: `canEdit` responde "consegue mexer neste usuário?"; `canManagePermissions` responde só "consegue mexer no acesso avulso de alguém?".

## 2. Reset de dedupe de flash era inalcançável

`use-flash-messages.tsx:37` lia `url` de `usePage().props`. O Inertia expõe `url` no **objeto de página**, não entre as props — e o `share()` não publica chave `url` nenhuma. `currentUrl` era sempre `''`, a chave global de dedupe (`${url}::${flash}`) colidia entre telas, e a mesma mensagem numa segunda página era engolida até o intervalo de limpeza de 10s passar.

## 3. `0` solto na tabela

`user-table-row.tsx:62` fazia `count && count > 0 && (…)`. Com `count === 0` — o caso comum, quase todo usuário tem zero permissões individuais — o primeiro operando é `0`, a expressão inteira vale `0`, e o React **renderiza o zero** na célula de cargo. Só sumia quando o campo vinha `undefined`.

## 4. Select de cargo vazio apagava o cargo e pulava o flush

`User/UpdateController`. `ConvertEmptyStringsToNull` transforma `role_id=''` em `null`, a regra é `nullable`, então o valor chega em `$data`. Mas o bloco que valida troca de cargo é guardado por `isset()`, que é **false** para null. O pior dos dois mundos:

- o `if` não entra → `$roleChanged` fica `false`;
- `$user->update($data)` grava `role_id = null` mesmo assim;
- o `Cache::forget` de `user:{id}:permissions`, que mora **dentro** daquele `if`, é pulado.

Cache é `rememberForever`: a pessoa perdia o cargo no banco e ficava com as permissões dele para sempre. Campo vazio agora significa "não mexer no cargo" — remover cargo tem rota própria (`user.revoke-role`).

## 5. Model inteiro do usuário em toda navegação

`HandleInertiaRequests::share()` publicava `'user' => $user`. O `$hidden` do model esconde apenas `password` e `remember_token`, então **`cpf_cnpj`, `phone`, `mobile` e `user_notes` viajavam em toda página do painel**, para qualquer tela, inclusive as que não têm nada a ver com dados pessoais.

O front lê exatamente quatro campos. Agora é `Arr::only(...)` com a lista em `SHARED_USER_FIELDS`, espelhada pelo tipo `AuthUser` no mesmo commit — `UserInfo` e `UserMenuContent`, os únicos consumidores, passaram a receber o tipo estreito.

### Consequência: um fallback morto caiu junto

`use-permissions.ts` tinha um fallback que lia `user.permissions` e `user.role` quando `auth.permissions`/`auth.roles` viessem vazios. Era um segundo canal com outro shape — e **sem dados**: as relations nunca foram eager-loaded no `share()`, então o fallback só devolvia lista vazia em qualquer cenário. Com `auth.user` estreitado ele também deixa de compilar. Removido.

O teste `use-permissions.test.ts > correctly checks user permissions` exercitava justamente esse caminho fantasma (mockava `auth.user.permissions`, shape que o servidor nunca mandou). Reescrito para o contrato real, e ganhou um irmão cobrindo a forma-objeto que o hook ainda aceita.

## Testes

Backend — `tests/Feature/SharedPropsTest.php` (novo) e um caso em `User/UpdateControllerTest.php`:

- `auth.user` tem exatamente 4 chaves; `cpf_cnpj`, `phone`, `mobile`, `user_notes`, `role_id` e `password` ausentes
- `auth.roles` e `auth.permissions` seguem publicados nas chaves próprias
- `role_id=''` preserva o cargo **e** mantém banco e cache contando a mesma história

Frontend — 3 arquivos novos:

- `use-user-permissions`: abre com `manage_permissions`, fecha com `manage_users` sozinho (o caso do MANAGER semeado), e `canEdit` segue no `manage_users`
- `use-flash-messages`: não repete na mesma página, **repete depois de navegar** (o caso que o bug matava), silencia sem flash
- `user-table-row`: sem `0` solto com contagem zero ou ausente, badge presente com contagem real

## Gates

- `composer ci:check` — Pint, Rector, larastan, 279 testes ✅
- `corepack pnpm ci:check` — ESLint, Prettier, tsc, 147 testes Vitest, build ✅

## Ficou fora, de propósito (vai para o PR E de higiene)

Três irmãos do bug 1, todos **sem consumidor** — corrigir agora seria mexer em código morto dentro de um PR de bugs vivos:

- `hooks/permissions/use-permission-permissions.ts:11` — mesmo defeito, mas só `canAssignRoles` é consumido daquele hook
- `utils/users/permissions.ts:115` — idem, alcançável só via `getUserChecks`, que ninguém chama
- `use-user-permissions.ts:65` — `canView()` checa `hasPermission('viewAny')`, que não é permissão nenhuma (é nome de método de policy): sempre falso, e também sem consumidor

🤖 Generated with [Claude Code](https://claude.com/claude-code)