### PR TITLE
[40] docs(painel): unifica o vocabulário e tira as promessas falsas do copy

### DIFF
--- a/app/Console/Commands/SyncPermissionsCommand.php
+++ b/app/Console/Commands/SyncPermissionsCommand.php
@@ -44,7 +44,7 @@ final class SyncPermissionsCommand extends Command
         {--dry-run : Mostra o que mudaria e não escreve nada}
         {--force : Não pedir confirmação em produção}';
 
-    protected $description = 'Sincroniza permissions e papéis dos enums com o banco, remove órfãs e invalida os caches de permissões';
+    protected $description = 'Sincroniza permissões e cargos dos enums com o banco, remove órfãos e invalida os caches de permissões';
 
     public function handle(): int
     {
@@ -120,7 +120,7 @@ final class SyncPermissionsCommand extends Command
 
         $this->newLine();
         $this->info(sprintf(
-            'Pronto: %d papéis, %d permissões, %d usuário(s) remanejado(s), caches de %d usuário(s) invalidados.',
+            'Pronto: %d cargos, %d permissões, %d usuário(s) remanejado(s), caches de %d usuário(s) invalidados.',
             Role::query()->count(),
             Permission::query()->count(),
             $orphanUsers->count(),
@@ -145,7 +145,7 @@ final class SyncPermissionsCommand extends Command
         array $missingPermissions,
     ): void {
         if ($missingRoles !== []) {
-            $this->info(sprintf('Papéis do enum ausentes no banco (%d): %s', count($missingRoles), implode(', ', $missingRoles)));
+            $this->info(sprintf('Cargos do enum ausentes no banco (%d): %s', count($missingRoles), implode(', ', $missingRoles)));
         }
 
         if ($missingPermissions !== []) {
@@ -153,13 +153,13 @@ final class SyncPermissionsCommand extends Command
         }
 
         if ($deadRoles->isEmpty() && $deadPermissions->isEmpty()) {
-            $this->info('Nenhum papel ou permissão órfã a remover.');
+            $this->info('Nenhum cargo ou permissão órfã a remover.');
 
             return;
         }
 
         if ($deadRoles->isNotEmpty()) {
-            $this->warn(sprintf('Papéis órfãos a remover (%d):', $deadRoles->count()));
+            $this->warn(sprintf('Cargos órfãos a remover (%d):', $deadRoles->count()));
             $this->line('  ' . $deadRoles->pluck('name')->implode(', '));
         }
 

--- a/app/Enum/Permissions.php
+++ b/app/Enum/Permissions.php
@@ -6,7 +6,7 @@ namespace App\Enum;
 
 enum Permissions: string
 {
-    // Gestão de Usuários/Papéis/Permissões
+    // Gestão de Usuários/Cargos/Permissões
     case MANAGE_USERS       = 'manage_users';
     case MANAGE_ROLES       = 'manage_roles';
     case MANAGE_PERMISSIONS = 'manage_permissions';
@@ -17,9 +17,9 @@ enum Permissions: string
     {
         return match ($this) {
             self::MANAGE_USERS       => 'Gerenciar Usuários',
-            self::MANAGE_ROLES       => 'Gerenciar Papéis',
+            self::MANAGE_ROLES       => 'Gerenciar Cargos',
             self::MANAGE_PERMISSIONS => 'Gerenciar Permissões',
-            self::ASSIGN_ROLES       => 'Atribuir Papéis',
+            self::ASSIGN_ROLES       => 'Atribuir Cargos',
             self::IMPERSONATE_USERS  => 'Personificar Usuários',
         };
     }

--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -28,6 +28,9 @@ class PasswordResetLinkController extends Controller
             $request->only('email')
         );
 
-        return back()->with('status', __('A reset link will be sent if the account exists.'));
+        // Sem chave em lang/pt_BR.json, o `__()` devolvia a própria string em
+        // inglês na tela de recuperação de senha. O painel não tem i18n — o
+        // texto em pt-BR fica aqui, como no resto da aplicação.
+        return back()->with('status', 'Se existir uma conta com esse e-mail, o link de redefinição será enviado.');
     }
 }

--- a/app/Http/Controllers/User/StartImpersonateController.php
+++ b/app/Http/Controllers/User/StartImpersonateController.php
@@ -24,7 +24,7 @@ final class StartImpersonateController extends Controller
 
         // Prevent starting new impersonation if already impersonating
         if ($this->impersonationService->isImpersonating()) {
-            abort(403, 'Você já está impersonando um usuário. Finalize a impersonação atual antes de iniciar outra.');
+            abort(403, 'Você já está usando o painel como outra pessoa. Volte para a sua conta antes de trocar de novo.');
         }
 
         // Manual user lookup since model binding is not working in tests
@@ -39,6 +39,6 @@ final class StartImpersonateController extends Controller
 
         return redirect()
             ->route('dashboard')
-            ->with('success', "Você está impersonando {$targetUser->name}");
+            ->with('success', "Você está usando o painel como {$targetUser->name}");
     }
 }

--- a/app/Http/Controllers/User/StopImpersonateController.php
+++ b/app/Http/Controllers/User/StopImpersonateController.php
@@ -19,7 +19,7 @@ final class StopImpersonateController extends Controller
     public function __invoke(Request $request): RedirectResponse
     {
         if (!$this->impersonationService->isImpersonating()) {
-            abort(403, 'Você não está personificando nenhum usuário.');
+            abort(403, 'Você não está usando o painel como outra pessoa.');
         }
 
         $originalUser = $this->impersonationService->stop();

--- a/lang/pt_BR/validation.php
+++ b/lang/pt_BR/validation.php
@@ -118,7 +118,7 @@ return [
         'mixed'         => 'O campo :attribute deve conter pelo menos uma letra maiúscula e uma minúscula.',
         'numbers'       => 'O campo :attribute deve conter pelo menos um número.',
         'symbols'       => 'O campo :attribute deve conter pelo menos um símbolo.',
-        'uncompromised' => 'O :attribute informado apareceu em um vazamento de dados. Escolha outro :attribute.',
+        'uncompromised' => 'O campo :attribute apareceu em um vazamento de dados conhecido. Escolha outra senha.',
     ],
     'present'                => 'O campo :attribute deve estar presente.',
     'present_if'             => 'O campo :attribute deve estar presente quando :other for :value.',

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -59,7 +59,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                                 </Button>
                             </SheetTrigger>
                             <SheetContent side="left" className="bg-sidebar flex h-full w-64 flex-col items-stretch justify-between">
-                                <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
+                                <SheetTitle className="sr-only">Menu de navegação</SheetTitle>
                                 <SheetHeader className="flex justify-start text-left">
                                     <AppLogoIcon className="h-6 w-6 fill-current text-black dark:text-white" />
                                 </SheetHeader>

--- a/resources/js/components/impersonate-banner.tsx
+++ b/resources/js/components/impersonate-banner.tsx
@@ -17,13 +17,13 @@ export function ImpersonateBanner({ active, originalUserName, impersonatedUserNa
         router.delete(route('users.impersonate.stop'));
     };
 
-    // Mostra o nome do usuário que está sendo impersonado (não o impersonador)
+    // Mostra o nome de quem está sendo usado como persona (não quem entrou)
     const displayName = impersonatedUserName || originalUserName || 'este usuário';
 
     return (
         <div className="mb-2 rounded-md bg-teal-500 px-4 py-1.5 text-center text-sm text-white">
             <span>
-                Você está impersonando <strong>{displayName}</strong>,{' '}
+                Você está usando o painel como <strong>{displayName}</strong>,{' '}
                 <a href="#" onClick={stopImpersonation} className="cursor-pointer underline hover:no-underline">
                     clique aqui para sair
                 </a>

--- a/resources/js/components/nav-main.tsx
+++ b/resources/js/components/nav-main.tsx
@@ -50,7 +50,7 @@ export function NavMain({ items = [] }: { items: NavItem[] }) {
 
     return (
         <SidebarGroup className="px-2 py-0">
-            <SidebarGroupLabel>Platform</SidebarGroupLabel>
+            <SidebarGroupLabel>Plataforma</SidebarGroupLabel>
             <SidebarMenu>
                 {filteredItems.map((item) => (
                     <SidebarMenuItem key={item.title}>

--- a/resources/js/components/permissions/role-info-dialog.tsx
+++ b/resources/js/components/permissions/role-info-dialog.tsx
@@ -5,64 +5,65 @@ import type { RoleInfoDialogProps } from '@/types/permissions';
 import { Filter, Shield, Sparkles, Zap } from 'lucide-react';
 
 /**
- * Componente de diálogo de informações sobre módulo de Permissões e Roles
+ * Diálogo de informações da tela de Cargos.
+ *
+ * O texto descreve o que esta tela faz de fato. A versão anterior prometia
+ * "múltiplas funções por usuário", que nunca existiu: `users.role_id` é único.
  */
 export function RoleInfoDialog({ open, onOpenChange }: RoleInfoDialogProps) {
     const sections: InfoSection[] = [
         {
-            title: 'Visão Geral',
+            title: 'Para que serve',
             icon: Shield,
             iconColor: 'text-cyan-600 dark:text-cyan-400',
             content: (
                 <p className="text-sm leading-relaxed">
-                    O módulo de Permissões permite gerenciar funções (roles) e suas permissões associadas. Cada função pode ter múltiplas permissões e
-                    usuários podem ser atribuídos a diferentes funções.
+                    Cada pessoa tem <strong>um cargo</strong>, e o cargo decide o que ela consegue fazer no painel. Aqui você define esse pacote: o
+                    que muda vale na hora para todo mundo que já está no cargo.
                 </p>
             ),
         },
         {
-            title: 'Funcionalidades Principais',
+            title: 'O que dá para fazer aqui',
             icon: Sparkles,
             iconColor: 'text-purple-600 dark:text-purple-400',
             content: (
                 <InfoFeatureList
                     features={[
-                        { label: 'Gerenciamento de funções (roles) e suas permissões' },
-                        { label: 'Atribuição de permissões a funções' },
-                        { label: 'Visualização de usuários por função' },
-                        { label: 'Atribuição e remoção de funções a usuários' },
-                        { label: 'Organização por abas para cada função' },
-                        { label: 'Salvamento em tempo real de alterações', badge: 'Tempo Real' },
+                        { label: 'Ver o que cada cargo libera hoje' },
+                        { label: 'Marcar e desmarcar acessos de um cargo' },
+                        { label: 'Ver quem está em cada cargo' },
+                        { label: 'Tirar alguém de um cargo pela tabela de usuários' },
                     ]}
                 />
             ),
         },
         {
-            title: 'Como Funciona',
+            title: 'Como usar',
             icon: Filter,
             iconColor: 'text-orange-600 dark:text-orange-400',
             content: (
                 <InfoFeatureList
                     features={[
-                        { label: 'Selecione uma função na sidebar lateral' },
-                        { label: 'Marque/desmarque permissões para a função' },
-                        { label: 'Clique em "Salvar Permissões" para aplicar' },
-                        { label: 'Visualize usuários com essa função na tabela' },
+                        { label: 'Escolha um cargo na lista à esquerda' },
+                        { label: 'Marque o que ele deve liberar' },
+                        { label: 'Clique em "Salvar Permissões"' },
+                        { label: 'Confira na tabela quem foi afetado' },
                     ]}
                 />
             ),
         },
         {
-            title: 'Dicas de Uso',
+            title: 'Antes de salvar',
             icon: Zap,
             iconColor: 'text-yellow-600 dark:text-yellow-400',
             content: (
                 <ul className="space-y-1.5 text-sm">
-                    <li>• As alterações de permissões são salvas por função</li>
-                    <li>• Usuários com uma função herdam todas as permissões dessa função</li>
-                    <li>• Você pode atribuir múltiplas funções a um usuário</li>
-                    <li>• Use a sidebar para navegar entre diferentes funções</li>
-                    <li>• As permissões são aplicadas imediatamente após salvar</li>
+                    <li>• Uma pessoa tem um cargo só — para trocar, use a tela de usuários</li>
+                    <li>• Tirar um acesso do cargo tira de todo mundo que está nele, na mesma hora</li>
+                    <li>• Você não consegue conceder um acesso que você mesmo não tem</li>
+                    <li>• Cargos acima do seu não aparecem para edição</li>
+                    <li>• Permissões extras dadas pessoa a pessoa continuam valendo, independentes do cargo</li>
                 </ul>
             ),
         },
@@ -72,8 +73,8 @@ export function RoleInfoDialog({ open, onOpenChange }: RoleInfoDialogProps) {
         <ModuleInfoDialog
             open={open}
             onOpenChange={onOpenChange}
-            title="Informações sobre Permissões"
-            description="Conheça as funcionalidades e recursos disponíveis no módulo de gerenciamento de permissões e funções."
+            title="Sobre a tela de Cargos"
+            description="O que cada cargo libera, e quem está em cada um."
             icon={Shield}
             iconBgColor="bg-cyan-100 dark:bg-cyan-900/40"
             iconColor="text-cyan-600 dark:text-cyan-300"

--- a/resources/js/components/permissions/role-users-table.tsx
+++ b/resources/js/components/permissions/role-users-table.tsx
@@ -136,7 +136,7 @@ export function RoleUsersTable({ users, roleLabel, assignableRoles = [], onRevok
                                         <div className="flex items-center justify-center py-12">
                                             <EmptyState
                                                 title="Nenhum usuário encontrado"
-                                                description={`Nenhum usuário foi encontrado com a função de ${roleLabel}.`}
+                                                description={`Ninguém está no cargo de ${roleLabel} ainda. Atribua o cargo pela tela de usuários.`}
                                                 icon={UserX}
                                                 type="row"
                                             />

--- a/resources/js/components/permissions/roles-sidebar.tsx
+++ b/resources/js/components/permissions/roles-sidebar.tsx
@@ -19,13 +19,13 @@ export function RolesSidebar({ roles, selectedRole, onSelectRole, totalRoles }: 
 
     return (
         <aside className="bg-card border-border/40 flex w-full shrink-0 flex-col overflow-hidden rounded-lg border shadow-sm lg:w-64 lg:max-w-xs">
-            {/* Funções Header */}
+            {/* Cargos Header */}
             <div className="bg-muted/20 border-border/30 border-b backdrop-blur-sm">
                 <div className="flex items-center gap-2 px-3 py-2">
                     <Shield className="h-4 w-4 text-cyan-600 transition-colors duration-200 dark:text-cyan-500" />
-                    <h2 className="dark:text-foreground text-base font-semibold tracking-tight">Funções</h2>
+                    <h2 className="dark:text-foreground text-base font-semibold tracking-tight">Cargos</h2>
                     <span className="text-muted-foreground/80 dark:text-muted-foreground/70 text-xs font-medium">
-                        • {totalRoles} {totalRoles === 1 ? 'função' : 'funções'}
+                        • {totalRoles} {totalRoles === 1 ? 'cargo' : 'cargos'}
                     </span>
                 </div>
             </div>

--- a/resources/js/components/settings/password-info-dialog.tsx
+++ b/resources/js/components/settings/password-info-dialog.tsx
@@ -23,10 +23,10 @@ export function PasswordInfoDialog({ open, onOpenChange }: PasswordInfoDialogPro
                         Sua senha é a primeira linha de defesa da sua conta. É importante usar uma senha forte e única para proteger suas informações.
                     </p>
                     <ul className="space-y-1.5 text-sm">
-                        <li>• Use pelo menos 8 caracteres</li>
-                        <li>• Combine letras maiúsculas, minúsculas, números e símbolos</li>
-                        <li>• Evite informações pessoais óbvias</li>
-                        <li>• Não reutilize senhas de outras contas</li>
+                        <li>• Quanto mais longa, melhor — comprimento vale mais que símbolo</li>
+                        <li>• Combine maiúsculas, minúsculas, números e símbolos</li>
+                        <li>• Evite nome, data de nascimento e coisas que estão no seu perfil</li>
+                        <li>• Não reutilize a senha de outra conta</li>
                     </ul>
                 </div>
             ),
@@ -47,17 +47,21 @@ export function PasswordInfoDialog({ open, onOpenChange }: PasswordInfoDialogPro
             ),
         },
         {
-            title: 'Requisitos de Senha',
+            title: 'O que o sistema exige',
             icon: Lock,
             iconColor: 'text-blue-600 dark:text-blue-400',
             content: (
-                <ul className="space-y-1.5 text-sm">
-                    <li>• Mínimo de 8 caracteres</li>
-                    <li>• Deve conter letras e números</li>
-                    <li>• Recomendado: símbolos especiais</li>
-                    <li>• Não pode ser igual à senha anterior</li>
-                    <li>• Deve ser diferente da senha atual</li>
-                </ul>
+                <div className="space-y-2 text-sm leading-relaxed">
+                    <ul className="space-y-1.5">
+                        <li>• Pelo menos 8 caracteres</li>
+                        <li>• A senha atual, para confirmar que é você</li>
+                        <li>• A nova senha digitada duas vezes iguais</li>
+                    </ul>
+                    <p className="text-muted-foreground">
+                        É só isso. Maiúsculas, números e símbolos ajudam muito, mas o sistema não obriga — a conta fica tão protegida quanto a senha
+                        que você escolher.
+                    </p>
+                </div>
             ),
         },
         {
@@ -66,11 +70,10 @@ export function PasswordInfoDialog({ open, onOpenChange }: PasswordInfoDialogPro
             iconColor: 'text-yellow-600 dark:text-yellow-400',
             content: (
                 <ul className="space-y-1.5 text-sm">
-                    <li>• Altere sua senha regularmente (a cada 3-6 meses)</li>
-                    <li>• Use um gerenciador de senhas para criar senhas fortes</li>
-                    <li>• Nunca compartilhe sua senha com ninguém</li>
-                    <li>• Se suspeitar de acesso não autorizado, altere imediatamente</li>
-                    <li>• Ative autenticação de dois fatores se disponível</li>
+                    <li>• Use um gerenciador de senhas: ele cria e guarda senhas fortes por você</li>
+                    <li>• Nunca compartilhe sua senha, nem com quem administra o painel</li>
+                    <li>• Suspeitou de acesso indevido? Troque na hora e avise o responsável</li>
+                    <li>• Trocar a senha por trocar não ajuda — troque quando houver motivo</li>
                 </ul>
             ),
         },
@@ -81,7 +84,7 @@ export function PasswordInfoDialog({ open, onOpenChange }: PasswordInfoDialogPro
             open={open}
             onOpenChange={onOpenChange}
             title="Informações sobre Senha"
-            description="Aprenda como gerenciar e proteger sua senha de acesso à plataforma."
+            description="O que o sistema exige, e o que de fato protege sua conta."
             icon={Lock}
             iconBgColor="bg-cyan-100 dark:bg-cyan-900/40"
             iconColor="text-cyan-600 dark:text-cyan-300"

--- a/resources/js/components/ui/breadcrumb.tsx
+++ b/resources/js/components/ui/breadcrumb.tsx
@@ -93,7 +93,7 @@ function BreadcrumbEllipsis({
       {...props}
     >
       <MoreHorizontal className="size-4" />
-      <span className="sr-only">More</span>
+      <span className="sr-only">Mais</span>
     </span>
   )
 }

--- a/resources/js/components/ui/dialog.tsx
+++ b/resources/js/components/ui/dialog.tsx
@@ -64,7 +64,7 @@ function DialogContent({
                 <DialogPrimitive.Close
                     className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4" >
                     <XIcon />
-                    <span className="sr-only" >Close</span >
+                    <span className="sr-only" >Fechar</span >
                 </DialogPrimitive.Close >
             </DialogPrimitive.Content >
         </DialogPortal >

--- a/resources/js/components/ui/sheet.tsx
+++ b/resources/js/components/ui/sheet.tsx
@@ -72,7 +72,7 @@ function SheetContent({
         {children}
         <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
           <XIcon className="size-4" />
-          <span className="sr-only">Close</span>
+          <span className="sr-only">Fechar</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>
     </SheetPortal>

--- a/resources/js/components/ui/sidebar.tsx
+++ b/resources/js/components/ui/sidebar.tsx
@@ -182,8 +182,8 @@ function Sidebar({
     return (
       <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
         <SheetHeader className="sr-only">
-          <SheetTitle>Sidebar</SheetTitle>
-          <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          <SheetTitle>Menu lateral</SheetTitle>
+          <SheetDescription>Menu lateral de navegação.</SheetDescription>
         </SheetHeader>
         <SheetContent
           data-sidebar="sidebar"
@@ -269,7 +269,7 @@ function SidebarTrigger({
       {...props}
     >
       <PanelLeftIcon />
-      <span className="sr-only">Toggle Sidebar</span>
+      <span className="sr-only">Abrir ou fechar o menu lateral</span>
     </Button>
   )
 }
@@ -281,10 +281,10 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
     <button
       data-sidebar="rail"
       data-slot="sidebar-rail"
-      aria-label="Toggle Sidebar"
+      aria-label="Abrir ou fechar o menu lateral"
       tabIndex={-1}
       onClick={toggleSidebar}
-      title="Toggle Sidebar"
+      title="Abrir ou fechar o menu lateral"
       className={cn(
         "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",

--- a/resources/js/components/user-details-dialog.tsx
+++ b/resources/js/components/user-details-dialog.tsx
@@ -94,7 +94,7 @@ export function UserDetailsDialog({ open, onOpenChange, user, canManagePermissio
                                 <div className="flex items-center space-x-2">
                                     <Mail className="text-muted-foreground h-4 w-4" />
                                     <div>
-                                        <p className="text-sm font-medium">Email</p>
+                                        <p className="text-sm font-medium">E-mail</p>
                                         <p className="text-muted-foreground text-sm">{user.email}</p>
                                     </div>
                                 </div>

--- a/resources/js/components/users/user-info-dialog.tsx
+++ b/resources/js/components/users/user-info-dialog.tsx
@@ -5,80 +5,82 @@ import type { UserInfoDialogProps } from '@/types/users';
 import { Filter, Shield, Sparkles, Users as UsersIcon, Zap } from 'lucide-react';
 
 /**
- * Componente específico de diálogo de informações sobre módulo de usuários
- * Usa o componente genérico ModuleInfoDialog internamente
+ * Diálogo de informações da tela de usuários.
+ *
+ * O texto lista só o que a tela faz. A versão anterior anunciava "histórico de
+ * atividades e auditoria" (o backend registra, mas não existe tela que mostre)
+ * e "ordenação por colunas" (o controller aceita `sort_by`, mas os cabeçalhos
+ * não são clicáveis).
  */
 export function UserInfoDialog({ open, onOpenChange }: UserInfoDialogProps) {
     const sections: InfoSection[] = [
         {
-            title: 'Visão Geral',
+            title: 'Para que serve',
             icon: UsersIcon,
             iconColor: 'text-cyan-600 dark:text-cyan-400',
             content: (
                 <p className="text-sm leading-relaxed">
-                    O módulo de Usuários centraliza o gerenciamento de todas as contas da plataforma, permitindo cadastro, edição, vinculação com
-                    cargos e controle de permissões.
+                    Aqui ficam todas as contas do painel. É por esta tela que alguém entra na plataforma, muda de cargo, perde o acesso ou é excluído
+                    de vez.
                 </p>
             ),
         },
         {
-            title: 'Funcionalidades Principais',
+            title: 'O que dá para fazer aqui',
             icon: Sparkles,
             iconColor: 'text-purple-600 dark:text-purple-400',
             content: (
                 <InfoFeatureList
                     features={[
-                        { label: 'Cadastro individual de usuários com dados completos' },
-                        { label: 'Gestão de perfis de acesso e permissões' },
-                        { label: 'Ativação/desativação de contas' },
-                        { label: 'Histórico de atividades e auditoria', badge: 'Auditoria' },
-                        { label: 'Busca e filtros avançados' },
-                        { label: 'Paginação eficiente para grandes volumes' },
+                        { label: 'Cadastrar uma pessoa e definir o cargo dela' },
+                        { label: 'Editar dados de cadastro' },
+                        { label: 'Desativar a conta — a pessoa deixa de entrar, o cadastro fica' },
+                        { label: 'Dar ou tirar acessos avulsos, fora do cargo' },
+                        { label: 'Excluir de vez, sem lixeira', badge: 'Definitivo' },
                     ]}
                 />
             ),
         },
         {
-            title: 'Filtros e Busca',
+            title: 'Achar alguém',
             icon: Filter,
             iconColor: 'text-orange-600 dark:text-orange-400',
             content: (
                 <InfoFeatureList
                     features={[
-                        { label: 'Busca textual - Pesquise por nome ou email' },
-                        { label: 'Filtro por Cargo - Visualize usuários por perfil' },
-                        { label: 'Filtro por Status - Ativo ou Inativo' },
-                        { label: 'Ordenação por colunas' },
+                        { label: 'Busca por nome ou e-mail, enquanto você digita' },
+                        { label: 'Filtro por cargo' },
+                        { label: 'Filtro por status: ativo ou inativo' },
                     ]}
                 />
             ),
         },
         {
-            title: 'Perfis de Acesso',
+            title: 'Cargos',
             icon: Shield,
             iconColor: 'text-red-600 dark:text-red-400',
             content: (
                 <InfoFeatureList
                     features={[
-                        { label: 'Super User - Acesso total ao sistema', badge: 'Máximo' },
-                        { label: 'Admin - Gerencia usuários e configurações', badge: 'Gestão' },
-                        { label: 'Manager - Acesso intermediário', badge: 'Intermediário' },
-                        { label: 'Outros perfis - Permissões customizadas', badge: 'Customizado' },
+                        { label: 'Super Usuário — faz tudo, inclusive sobre outros super usuários', badge: 'Máximo' },
+                        { label: 'Administrador — gerencia pessoas e cargos abaixo do dele', badge: 'Gestão' },
+                        { label: 'Gerente — cuida da equipe, sem mexer em cargos e permissões' },
+                        { label: 'Visualizador e Visitante — sem acesso de gestão' },
                     ]}
                 />
             ),
         },
         {
-            title: 'Dicas de Uso',
+            title: 'Bom saber',
             icon: Zap,
             iconColor: 'text-yellow-600 dark:text-yellow-400',
             content: (
                 <ul className="space-y-1.5 text-sm">
-                    <li>• A busca é instantânea e procura em nome e email simultaneamente</li>
-                    <li>• Combine filtros de cargo e status para segmentar usuários</li>
-                    <li>• Ao editar, você pode alterar cargo e permissões vinculadas</li>
-                    <li>• Usuários inativos não conseguem fazer login na plataforma</li>
-                    <li>• Use os ícones de ação rápida na tabela para operações frequentes</li>
+                    <li>• Quem está inativo não entra no painel, mas continua na lista</li>
+                    <li>• Sem o e-mail confirmado, a pessoa também não entra</li>
+                    <li>• Você só age sobre quem está abaixo do seu cargo — nem sobre iguais, nem sobre você mesmo</li>
+                    <li>• Excluir é definitivo: para tirar o acesso sem perder o cadastro, desative</li>
+                    <li>• Acessos avulsos somam aos do cargo e não somem quando o cargo muda</li>
                 </ul>
             ),
         },
@@ -88,8 +90,8 @@ export function UserInfoDialog({ open, onOpenChange }: UserInfoDialogProps) {
         <ModuleInfoDialog
             open={open}
             onOpenChange={onOpenChange}
-            title="Informações sobre Usuários"
-            description="Conheça as funcionalidades e recursos disponíveis no módulo de gerenciamento de usuários."
+            title="Sobre a tela de usuários"
+            description="Quem entra no painel, com qual cargo, e o que cada ação faz de verdade."
             icon={UsersIcon}
             iconBgColor="bg-cyan-100 dark:bg-cyan-900/40"
             iconColor="text-cyan-600 dark:text-cyan-300"

--- a/resources/js/components/users/user-show-info-dialog.tsx
+++ b/resources/js/components/users/user-show-info-dialog.tsx
@@ -61,19 +61,19 @@ export function UserShowInfoDialog({ open, onOpenChange }: UserInfoDialogProps) 
             content: (
                 <ul className="space-y-1.5 text-sm">
                     <li>
-                        • <strong>Status Ativo:</strong> Usuários inativos não conseguem fazer login
+                        • <strong>Status:</strong> quem está inativo não entra no painel, mas continua na lista
                     </li>
                     <li>
-                        • <strong>Cargo:</strong> Define permissões base do usuário
+                        • <strong>Cargo:</strong> o pacote de acessos que a pessoa herda
                     </li>
                     <li>
-                        • <strong>Permissões Diretas:</strong> Permissões extras além das do cargo
+                        • <strong>Permissões extras:</strong> acessos dados a esta pessoa, que somam aos do cargo
                     </li>
                     <li>
-                        • <strong>Email Verificado:</strong> Indica se o email foi confirmado
+                        • <strong>E-mail verificado:</strong> sem confirmar, a pessoa não entra no painel
                     </li>
                     <li>
-                        • <strong>Notas:</strong> Informações adicionais registradas sobre o usuário
+                        • <strong>Notas:</strong> anotações internas, visíveis só para quem administra
                     </li>
                 </ul>
             ),

--- a/resources/js/layouts/permissions/layout.tsx
+++ b/resources/js/layouts/permissions/layout.tsx
@@ -22,7 +22,7 @@ export default function PermissionsLayout({ roles, children }: PermissionsLayout
                 <Tabs.Root defaultValue="admin" className={'flex flex-1 flex-col gap-x-8 sm:flex-row sm:justify-between'}>
                     <Flex gap={'4'} className="flex flex-1 flex-col space-y-8 gap-x-8 sm:flex-row sm:space-y-0 sm:space-x-6">
                         <aside className="w-full max-w-3xl sm:w-52">
-                            <HeadingSmall title="Funções/Cargos" description={'Funções e Permissões.'} />
+                            <HeadingSmall title="Cargos" description={'Escolha um cargo para ver e mudar o que ele libera.'} />
                             <Tabs.List className={'mt-6 !shadow-none'}>
                                 <nav className="flex w-full flex-col space-y-1 space-x-0">
                                     {roles &&

--- a/resources/js/pages/auth/forgot-password.tsx
+++ b/resources/js/pages/auth/forgot-password.tsx
@@ -35,7 +35,7 @@ export default function ForgotPassword({ status }: { status?: string }) {
             <div className="space-y-6">
                 <form onSubmit={submit}>
                     <div className="grid gap-2">
-                        <Label htmlFor="email">Email </Label>
+                        <Label htmlFor="email">E-mail</Label>
                         <Input
                             id="email"
                             type="email"

--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -49,7 +49,7 @@ export default function Login({ status, canResetPassword }: LoginProps) {
             <form className="flex flex-col gap-6" onSubmit={submit}>
                 <div className="grid gap-6">
                     <div className="grid gap-2">
-                        <Label htmlFor="email">Email </Label>
+                        <Label htmlFor="email">E-mail</Label>
                         <Input
                             id="email"
                             type="email"

--- a/resources/js/pages/auth/register.tsx
+++ b/resources/js/pages/auth/register.tsx
@@ -54,7 +54,7 @@ export default function Register() {
                     </div>
 
                     <div className="grid gap-2">
-                        <Label htmlFor="email">Email </Label>
+                        <Label htmlFor="email">E-mail</Label>
                         <Input
                             id="email"
                             type="email"

--- a/resources/js/pages/auth/reset-password.tsx
+++ b/resources/js/pages/auth/reset-password.tsx
@@ -42,7 +42,7 @@ export default function ResetPassword({ token, email }: ResetPasswordProps) {
             <form onSubmit={submit}>
                 <div className="grid gap-6">
                     <div className="grid gap-2">
-                        <Label htmlFor="email">Email</Label>
+                        <Label htmlFor="email">E-mail</Label>
                         <Input id="email" type="email" name="email" autoComplete="email" value={data.email} readOnly disabled={processing} />
                         <InputError message={errors.email} className="mt-2" />
                     </div>

--- a/resources/js/pages/permission-role/roles.tsx
+++ b/resources/js/pages/permission-role/roles.tsx
@@ -110,13 +110,13 @@ export default function Roles({ roles, assignableRoles = [], permissions }: Perm
                         <SheetTrigger asChild>
                             <Button variant="outline" size="sm" className="w-full justify-start gap-2 sm:w-auto">
                                 <Menu className="h-4 w-4 shrink-0" />
-                                <span className="font-medium">Funções</span>
+                                <span className="font-medium">Cargos</span>
                                 <span className="text-muted-foreground truncate text-xs">• {selectedRoleData.label}</span>
                             </Button>
                         </SheetTrigger>
                         <SheetContent side="left" className="w-80 p-0 sm:max-w-sm">
                             <SheetHeader className="sr-only">
-                                <SheetTitle>Selecionar Função</SheetTitle>
+                                <SheetTitle>Selecionar cargo</SheetTitle>
                             </SheetHeader>
                             <div className="h-full overflow-y-auto">
                                 <RolesSidebar roles={roles} selectedRole={selectedRole} onSelectRole={handleRoleSelect} totalRoles={totalRoles} />
@@ -127,7 +127,7 @@ export default function Roles({ roles, assignableRoles = [], permissions }: Perm
 
                 {/* Main Content */}
                 <div className="flex flex-1 flex-col gap-3 overflow-hidden lg:flex-row lg:gap-4">
-                    {/* Sidebar - Roles Navigation (Desktop) */}
+                    {/* Sidebar - Navegação de cargos (Desktop) */}
                     <div className="hidden lg:block">
                         <RolesSidebar roles={roles} selectedRole={selectedRole} onSelectRole={setSelectedRole} totalRoles={totalRoles} />
                     </div>
@@ -149,7 +149,7 @@ export default function Roles({ roles, assignableRoles = [], permissions }: Perm
                                                 variant="ghost"
                                                 size="icon"
                                                 className="h-6 w-6 shrink-0 transition-all duration-200 ease-in-out hover:scale-105 hover:bg-cyan-50 hover:text-cyan-700 active:scale-95 dark:hover:bg-cyan-950/20 dark:hover:text-cyan-400"
-                                                aria-label="Informações sobre o módulo de permissões"
+                                                aria-label="Sobre a tela de cargos"
                                             >
                                                 <Info className="text-muted-foreground dark:text-muted-foreground/80 h-4 w-4 transition-colors duration-200" />
                                             </Button>
@@ -167,7 +167,7 @@ export default function Roles({ roles, assignableRoles = [], permissions }: Perm
                                     data-active
                                 >
                                     <Shield className="h-3.5 w-3.5" />
-                                    Roles
+                                    Cargos
                                 </Button>
                             </div>
                         </div>
@@ -184,7 +184,7 @@ export default function Roles({ roles, assignableRoles = [], permissions }: Perm
                                         </div>
                                         <div className="mt-1 flex flex-wrap items-center gap-2 sm:gap-3">
                                             <p className="text-muted-foreground dark:text-muted-foreground/70 text-xs sm:text-sm">
-                                                Gerencie as permissões e usuários desta função
+                                                Quem tem este cargo passa a poder fazer o que estiver marcado abaixo
                                             </p>
                                             <span className="text-muted-foreground dark:text-muted-foreground/50 hidden text-xs sm:inline">•</span>
                                             <span className="text-muted-foreground dark:text-muted-foreground/70 text-xs">
@@ -228,7 +228,7 @@ export default function Roles({ roles, assignableRoles = [], permissions }: Perm
                                         <h3 className="dark:text-foreground text-base font-semibold">Permissões Disponíveis</h3>
                                     </div>
                                     <p className="text-muted-foreground dark:text-muted-foreground/70 text-sm">
-                                        Selecione as permissões que esta função deve possuir
+                                        Marque o que este cargo libera. Vale na hora para todo mundo que já o tem.
                                     </p>
                                 </div>
                                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
@@ -250,9 +250,7 @@ export default function Roles({ roles, assignableRoles = [], permissions }: Perm
                                         <Users className="h-4 w-4 text-cyan-600 transition-colors duration-200 dark:text-cyan-500" />
                                         <h3 className="dark:text-foreground text-base font-semibold">Usuários</h3>
                                     </div>
-                                    <p className="text-muted-foreground dark:text-muted-foreground/70 mt-1 text-sm">
-                                        Usuários que possuem esta função
-                                    </p>
+                                    <p className="text-muted-foreground dark:text-muted-foreground/70 mt-1 text-sm">Quem está neste cargo hoje</p>
                                 </div>
                                 <RoleUsersTable
                                     users={usersArray}

--- a/resources/js/pages/settings/profile.tsx
+++ b/resources/js/pages/settings/profile.tsx
@@ -136,7 +136,7 @@ export default function Profile({ mustVerifyEmail, status }: ProfilePageProps) {
                                                     <h3 className="dark:text-foreground text-base font-semibold">Dados Pessoais</h3>
                                                 </div>
                                                 <p className="text-muted-foreground dark:text-muted-foreground/70 text-sm">
-                                                    Atualize seu nome e endereço de email
+                                                    Atualize seu nome e endereço de e-mail
                                                 </p>
                                             </div>
 
@@ -156,7 +156,7 @@ export default function Profile({ mustVerifyEmail, status }: ProfilePageProps) {
                                                 </div>
 
                                                 <div className="grid gap-2">
-                                                    <Label htmlFor="email">Endereço de Email</Label>
+                                                    <Label htmlFor="email">Endereço de e-mail</Label>
                                                     <Input
                                                         id="email"
                                                         type="email"
@@ -165,7 +165,7 @@ export default function Profile({ mustVerifyEmail, status }: ProfilePageProps) {
                                                         onChange={(e) => setData((prev) => ({ ...prev, email: e.target.value }))}
                                                         required
                                                         autoComplete="username"
-                                                        placeholder="Endereço de email"
+                                                        placeholder="Endereço de e-mail"
                                                     />
                                                     <InputError message={errors.email} />
                                                 </div>
@@ -174,28 +174,28 @@ export default function Profile({ mustVerifyEmail, status }: ProfilePageProps) {
 
                                         <Separator />
 
-                                        {/* Email Verification Section */}
+                                        {/* Verificação de e-mail */}
                                         {mustVerifyEmail && auth.user.email_verified_at === null && (
                                             <div>
                                                 <div className="mb-2 flex items-center gap-2">
                                                     <Mail className="h-4 w-4 text-cyan-600 transition-colors duration-200 dark:text-cyan-500" />
-                                                    <h3 className="dark:text-foreground text-base font-semibold">Verificação de Email</h3>
+                                                    <h3 className="dark:text-foreground text-base font-semibold">Verificação de e-mail</h3>
                                                 </div>
                                                 <p className="text-muted-foreground dark:text-muted-foreground/70 text-sm">
-                                                    Seu endereço de email não foi verificado.{' '}
+                                                    Seu endereço de e-mail não foi verificado.{' '}
                                                     <Link
                                                         href={route('verification.send')}
                                                         method="post"
                                                         as="button"
                                                         className="text-foreground underline decoration-neutral-300 underline-offset-4 transition-colors duration-300 ease-out hover:decoration-current! dark:decoration-neutral-500"
                                                     >
-                                                        Clique aqui para reenviar o email de verificação.
+                                                        Clique aqui para reenviar o e-mail de verificação.
                                                     </Link>
                                                 </p>
 
                                                 {status === 'verification-link-sent' && (
                                                     <div className="mt-2 text-sm font-medium text-green-600 dark:text-green-500">
-                                                        Um novo link de verificação foi enviado para seu endereço de email.
+                                                        Um novo link de verificação foi enviado para seu endereço de e-mail.
                                                     </div>
                                                 )}
                                             </div>

--- a/resources/js/pages/users/index.tsx
+++ b/resources/js/pages/users/index.tsx
@@ -124,7 +124,7 @@ export default function Index({ users, roles, assignableRoles = [], filters = {}
     const tableColumns = useMemo(
         () => [
             { key: 'name', label: 'Nome', icon: User2 },
-            { key: 'email', label: 'Email', icon: Mail },
+            { key: 'email', label: 'E-mail', icon: Mail },
             { key: 'mobile', label: 'Celular', icon: Phone },
             { key: 'role', label: 'Cargo', icon: Shield },
             { key: 'status', label: 'Status', icon: CheckCircle },
@@ -134,7 +134,7 @@ export default function Index({ users, roles, assignableRoles = [], filters = {}
 
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
-            <Head title="Gerenciamento de Usuários" />
+            <Head title="Usuários" />
             {/* Aria live region for screen readers */}
             <div aria-live="polite" aria-atomic="true" className="sr-only">
                 {isSearching ? 'Buscando usuários...' : ''}
@@ -154,7 +154,7 @@ export default function Index({ users, roles, assignableRoles = [], filters = {}
                                             variant="ghost"
                                             size="icon"
                                             className="hover:bg-accent/50 dark:hover:bg-accent/20 hover:text-primary dark:hover:text-primary/90 h-6 w-6 transition-all duration-200 ease-in-out hover:scale-105 active:scale-95"
-                                            aria-label="Informações sobre o módulo de usuários"
+                                            aria-label="Sobre a tela de usuários"
                                         >
                                             <Info className="text-muted-foreground dark:text-muted-foreground/80 h-4 w-4 transition-colors duration-200" />
                                         </Button>
@@ -274,13 +274,13 @@ export default function Index({ users, roles, assignableRoles = [], filters = {}
                                             <EmptyState
                                                 title={
                                                     filters.search || filters.role_id !== undefined || filters.is_active !== undefined
-                                                        ? 'Nenhum usuário encontrado com os filtros aplicados'
-                                                        : 'Nenhum usuário encontrado'
+                                                        ? 'Nenhum usuário bate com esses filtros'
+                                                        : 'Nenhum usuário cadastrado ainda'
                                                 }
                                                 description={
                                                     filters.search || filters.role_id !== undefined || filters.is_active !== undefined
-                                                        ? 'Tente ajustar os critérios de busca ou limpar os filtros'
-                                                        : 'Não há usuários cadastrados no sistema'
+                                                        ? 'Limpe os filtros ou tente outro termo de busca'
+                                                        : 'Clique em "Novo Usuário" para cadastrar o primeiro'
                                                 }
                                                 icon={User2}
                                             />
@@ -309,26 +309,26 @@ export default function Index({ users, roles, assignableRoles = [], filters = {}
                 onOpenChange={setShowDeleteDialog}
                 onConfirm={handleDelete}
                 title="Excluir Usuário"
-                description="Tem certeza que deseja remover este usuário permanentemente da plataforma?"
+                description="O cadastro é apagado de vez. Não existe lixeira nem como recuperar depois."
                 itemName={userToDelete?.name}
                 itemType="Usuário"
                 icon={User2}
                 details={
                     userToDelete
                         ? [
-                              { label: 'Email', value: userToDelete.email, icon: Mail },
+                              { label: 'E-mail', value: userToDelete.email, icon: Mail },
                               { label: 'Cargo', value: userToDelete.role?.label || 'Não definido', icon: Shield },
                           ]
                         : []
                 }
                 warnings={[
                     {
-                        message: 'Todo o histórico de atividades deste usuário será permanentemente removido.',
-                        severity: 'danger',
+                        message: 'Se você só quer tirar o acesso, desative a conta: a pessoa não entra mais e o cadastro fica.',
+                        severity: 'warning',
                     },
                     {
-                        message: 'O usuário perderá acesso imediato à plataforma e não poderá fazer login.',
-                        severity: 'warning',
+                        message: 'O registro de auditoria das ações desta pessoa permanece, sem vínculo com o cadastro apagado.',
+                        severity: 'danger',
                     },
                 ]}
                 variant="danger"
@@ -386,7 +386,7 @@ export default function Index({ users, roles, assignableRoles = [], filters = {}
                 details={
                     userToRevokeRole
                         ? [
-                              { label: 'Email', value: userToRevokeRole.email, icon: Mail },
+                              { label: 'E-mail', value: userToRevokeRole.email, icon: Mail },
                               { label: 'Cargo Atual', value: userToRevokeRole.role?.label || 'Não definido', icon: Shield },
                           ]
                         : []

--- a/resources/js/pages/users/permissions.tsx
+++ b/resources/js/pages/users/permissions.tsx
@@ -106,7 +106,7 @@ export default function UserPermissions({ user, all_permissions }: UserPermissio
                             <div className="flex min-w-0 flex-wrap items-center gap-2">
                                 <Shield className="h-4 w-4 shrink-0 text-cyan-600 transition-colors duration-200 dark:text-cyan-500" />
                                 <h2 className="truncate text-base font-semibold tracking-tight">Permissões: {user.name}</h2>
-                                <span className="text-muted-foreground/80 text-xs font-medium">• Gerenciamento</span>
+                                <span className="text-muted-foreground/80 text-xs font-medium">• O que esta pessoa pode fazer</span>
                             </div>
                             <div className="flex items-center gap-2">
                                 <Link href={route('users.index')}>

--- a/resources/js/pages/users/show.tsx
+++ b/resources/js/pages/users/show.tsx
@@ -94,7 +94,7 @@ export default function Show({ user }: ShowUserProps) {
                                                 <p className="text-foreground text-sm font-medium">{user.name}</p>
                                             </div>
                                             <div className="space-y-1.5">
-                                                <p className="text-muted-foreground text-xs font-medium">Email</p>
+                                                <p className="text-muted-foreground text-xs font-medium">E-mail</p>
                                                 <div className="flex items-center gap-1.5">
                                                     <Mail className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
                                                     <p className="text-foreground text-sm break-all">{user.email}</p>
@@ -176,7 +176,7 @@ export default function Show({ user }: ShowUserProps) {
                                                     ) : (
                                                         <>
                                                             <XCircle className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-                                                            <p className="text-muted-foreground text-sm">Não verificado</p>
+                                                            <p className="text-muted-foreground text-sm">Não verificado — o painel fica bloqueado</p>
                                                         </>
                                                     )}
                                                 </div>
@@ -230,13 +230,13 @@ export default function Show({ user }: ShowUserProps) {
                                     </Card>
                                 )}
 
-                                {/* Card: Permissões Diretas */}
+                                {/* Card: Permissões Extras */}
                                 {user.permissions && user.permissions.length > 0 && (
                                     <Card className="border-border/40">
                                         <CardContent className="px-4 py-1.5 sm:px-6">
                                             <div className="mb-4 flex items-center gap-2">
                                                 <Shield className="h-4 w-4 text-cyan-600 transition-colors duration-200 dark:text-cyan-500" />
-                                                <h3 className="text-foreground text-base font-semibold">Permissões Diretas</h3>
+                                                <h3 className="text-foreground text-base font-semibold">Permissões Extras</h3>
                                                 <span className="text-muted-foreground/70 text-xs">
                                                     ({user.permissions.length} {user.permissions.length === 1 ? 'permissão' : 'permissões'})
                                                 </span>

--- a/tests/Feature/Console/SyncPermissionsCommandTest.php
+++ b/tests/Feature/Console/SyncPermissionsCommandTest.php
@@ -35,7 +35,7 @@ it('is idempotent on a database already in sync', function(): void {
     $this->seed(PermissionRoleSeeder::class);
 
     $this->artisan('permissions:sync')
-        ->expectsOutputToContain('Nenhum papel ou permissão órfã a remover.')
+        ->expectsOutputToContain('Nenhum cargo ou permissão órfã a remover.')
         ->assertSuccessful();
 
     expect(Role::query()->count())->toBe(count(Roles::cases()))

--- a/tests/Feature/CopyPainelTest.php
+++ b/tests/Feature/CopyPainelTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Enum\Permissions;
+use App\Enum\Roles;
+
+/*
+ * Guardas de copy. Não testam comportamento — testam que o painel volta a falar
+ * em quatro termos diferentes, ou a devolver inglês, sem ninguém perceber.
+ */
+
+// region Terminologia
+
+test('permission labels use "Cargos", the single term for role', function(): void {
+    expect(Permissions::MANAGE_ROLES->label())->toBe('Gerenciar Cargos')
+        ->and(Permissions::ASSIGN_ROLES->label())->toBe('Atribuir Cargos');
+});
+
+test('no visible label falls back to the abandoned terms', function(): void {
+    // "Papéis" e "Funções" conviviam com "Cargo" e com "Roles" em inglês cru.
+    $labels = [
+        ...array_map(fn(Permissions $p): string => $p->label(), Permissions::cases()),
+        ...array_map(fn(Roles $r): string => $r->label(), Roles::cases()),
+    ];
+
+    foreach ($labels as $label) {
+        expect($label)
+            ->not->toContain('Papéis')
+            ->not->toContain('Papel')
+            ->not->toContain('Funções')
+            ->not->toContain('Função');
+    }
+});
+
+test('seeding carries the enum label into the database the screen reads', function(): void {
+    // A tela de cargos monta os cards com `permissions.label` vindo do BANCO
+    // (`PermissionRole/IndexController`), não do enum. Trocar a palavra no enum
+    // só aparece depois de `php artisan permissions:sync` — ou de um deploy que
+    // rode o seeder.
+    $this->seed(Database\Seeders\PermissionRoleSeeder::class);
+
+    $label = App\Models\Permission::query()
+        ->where('name', Permissions::MANAGE_ROLES->value)
+        ->value('label');
+
+    expect($label)->toBe(Permissions::MANAGE_ROLES->label());
+});
+
+// endregion
+// region Nada de inglês vazando
+
+test('the password reset status reaches the user in pt-BR', function(): void {
+    // Vinha de `__('A reset link will be sent if the account exists.')`, chave
+    // inexistente em lang/pt_BR.json — o `__()` devolvia a própria string.
+    $this->post(route('password.email'), ['email' => 'ninguem@example.com'])
+        ->assertSessionHas('status');
+
+    $status = session('status');
+
+    expect($status)
+        ->toBeString()
+        ->not->toContain('reset link')
+        ->toContain('link de redefinição');
+});
+
+test('the uncompromised password message agrees in gender', function(): void {
+    // Rendia "O senha informado… Escolha outro senha".
+    $message = __('validation.password.uncompromised', ['attribute' => 'senha']);
+
+    expect($message)
+        ->toBeString()
+        ->not->toContain('O senha')
+        ->not->toContain('outro senha')
+        ->toContain('senha');
+});
+
+// endregion
+// region Impersonação em português
+
+test('starting impersonation says it in Portuguese', function(): void {
+    actingAsSuperUser();
+    $target = guestUser();
+
+    $this->post(route('users.impersonate', $target))
+        ->assertRedirect(route('dashboard'));
+
+    expect(session('success'))
+        ->not->toContain('impersonando')
+        ->toContain('usando o painel como');
+});
+
+test('refusing a second impersonation says it in Portuguese', function(): void {
+    // A persona precisa ter `impersonate_users`, senão o 403 vem do middleware
+    // `can:` da rota e a mensagem do controller nunca é alcançada.
+    actingAsSuperUser();
+    $first  = userWithRole(Roles::SUPER_USER);
+    $second = guestUser();
+
+    $this->post(route('users.impersonate', $first))->assertRedirect(route('dashboard'));
+
+    $response = $this->post(route('users.impersonate', $second));
+
+    $response->assertForbidden();
+
+    expect($response->exception?->getMessage())
+        ->not->toContain('impersonando')
+        ->toContain('usando o painel como outra pessoa');
+});
+
+test('stopping an impersonation that never started says it in Portuguese', function(): void {
+    actingAsSuperUser();
+
+    $response = $this->delete(route('users.impersonate.stop'));
+
+    $response->assertForbidden();
+
+    expect($response->exception?->getMessage())
+        ->not->toContain('personificando')
+        ->toContain('usando o painel como outra pessoa');
+});
+
+// endregion


### PR DESCRIPTION
Fecha #40. Harvest reversa do `spinmax` — PR C de cinco. **Só string**: nenhuma rota, chave de props, nome de permissão ou comportamento muda. Separado de propósito para a review poder ser lida como texto.

## Um termo para "cargo"

O painel usava quatro ao mesmo tempo: **"Papéis"** (enum), **"Funções"** (sidebar, aba mobile, layout), **"Roles"** em inglês cru (aba visível da tela de cargos) e **"Cargo"** (todo o resto — filtros, formulário, menu de ações). O `layouts/permissions/layout.tsx` hesitava no meio, com título "Funções/Cargos".

Padronizado em **Cargos**, que já era o majoritário. `role`, `role_id`, rotas e chaves de props seguem em inglês — mexer nisso quebraria o contrato shared props ↔ types.

Estendi para a saída do `permissions:sync`, que também dizia "Papéis": é o mesmo termo, e é o texto que alguém lê no meio de um incidente. Um teste existente que casava com a frase antiga foi atualizado.

## Inglês solto num painel pt-BR

"Platform", "Navigation Menu", "Sidebar", "Displays the mobile sidebar.", "Toggle Sidebar" ×3, "Close" ×2, "More". A maioria é `sr-only`/`aria-label` — ou seja, era exatamente o que o leitor de tela anunciava.

## Diálogos que prometiam o que o sistema não faz

Cada um verificado contra o código antes de reescrever:

| Promessa | Realidade |
|---|---|
| "Você pode atribuir múltiplas funções a um usuário" | `users.role_id` é **único** |
| "Histórico de atividades e auditoria" (badge "Auditoria") | O backend registra em `activity_log`, mas **não existe tela** que mostre — o único arquivo do front que menciona auditoria era esse diálogo |
| "Ordenação por colunas" | O `IndexController` aceita `sort_by`, mas `users/index.tsx` não tem **uma única** referência a sort: os cabeçalhos não são clicáveis |
| "Deve conter letras e números", "Não pode ser igual à senha anterior", "Deve ser diferente da senha atual" | `Password::defaults()` nunca é customizado: a regra real é **só `min(8)`** |

O diálogo de senha agora separa **o que o sistema exige** do **que de fato protege a conta** — as recomendações continuam lá, sem se disfarçar de requisito.

## A confirmação de exclusão também mentia

Avisava: "Todo o histórico de atividades deste usuário será permanentemente removido."

`activity_log` usa `nullableMorphs` — **sem foreign key e sem cascade**. Os registros não são removidos: ficam órfãos. O que acontece de verdade é que o `User` não tem `SoftDeletes`, então o cadastro some de vez.

O diálogo passa a dizer isso, e a oferecer a alternativa segura, que existe e ninguém mencionava: **desativar a conta**.

## Padrão editorial

Consequência em vez de nome de tela; estado vazio acionável:

- "Não há usuários cadastrados no sistema" → "Clique em \"Novo Usuário\" para cadastrar o primeiro"
- "Permissões Diretas" → "Permissões Extras"
- "Gerenciamento" → "O que esta pessoa pode fazer"
- "Não verificado" → "Não verificado — o painel fica bloqueado"
- "Selecione as permissões que esta função deve possuir" → "Marque o que este cargo libera. Vale na hora para todo mundo que já o tem."
- "Nenhum usuário foi encontrado com a função de X" → "Ninguém está no cargo de X ainda. Atribua o cargo pela tela de usuários."

## "impersonando" não é palavra em português

Trocado por **"usando o painel como"** na faixa do topo (a mais visível do painel) e nas mensagens dos dois controllers. A permissão `impersonate_users` **não** muda de nome.

## Duas quebras em `lang/`

- `password.uncompromised` rendia **"O senha informado… Escolha outro senha"**. Hoje é inalcançável — a regra `uncompromised` não está ligada —, mas derivados que a liguem herdariam a frase quebrada.
- `PasswordResetLinkController` chamava `__('A reset link will be sent if the account exists.')`, chave inexistente em `pt_BR.json`, e o usuário lia **inglês** na tela de recuperação de senha. Como o painel não tem i18n (todo o pt-BR está hardcoded no `.tsx`), o texto passa a morar no controller — e assim não fica refém da decisão sobre o `pt_BR.json`, que é assunto do PR E.

## Testes

`tests/Feature/CopyPainelTest.php` (8 casos) guarda o que apodrece em silêncio: o termo único nos labels do enum, o inglês vazando na recuperação de senha, a concordância do `uncompromised` e a copy de impersonação nos três pontos.

Todos os 8 falham contra o código antigo.

Um caso escreveu uma descoberta em vez de só assertar: **a tela lê `permissions.label` do BANCO**, não do enum (`PermissionRole/IndexController` faz `Permission::all()`). Ou seja — veja abaixo.

Um detalhe apareceu ao escrever os testes: o 403 da segunda impersonação **não** vem do `StartImpersonateController`, e sim do middleware `can:impersonate_users` da rota, sempre que a persona não tem a permissão. A mensagem do controller só é alcançável quando a persona também a tem. O teste foi ajustado para exercitar o caminho real.

## ⚠️ Requer `permissions:sync` no deploy

`Permissions::label()` mudou, e a tela de cargos renderiza o label **vindo do banco**. Sem rodar `php artisan permissions:sync` (ou um deploy que execute o seeder), a interface continua mostrando "Gerenciar Papéis" mesmo com este PR mergeado.

## Gates

- `composer ci:check` — Pint, Rector, larastan, 287 testes ✅
- `corepack pnpm ci:check` — ESLint, Prettier, tsc, 147 Vitest, build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)