### PR TITLE
[42] feat(rbac): descreve o que cada permissão e cada cargo libera

### DIFF
--- a/app/Enum/Permissions.php
+++ b/app/Enum/Permissions.php
@@ -23,4 +23,21 @@ enum Permissions: string
             self::IMPERSONATE_USERS  => 'Personificar Usuários',
         };
     }
+
+    /**
+     * O que a pessoa passa a conseguir fazer — em consequência, não em nome de
+     * tela. Quem monta um cargo no painel decide por esta frase, então ela vale
+     * mais que o label: "Gerenciar Permissões" e "Atribuir Cargos" são parecidos
+     * o bastante para serem trocados um pelo outro.
+     */
+    public function description(): string
+    {
+        return match ($this) {
+            self::MANAGE_USERS       => 'Criar, editar, desativar e excluir quem entra no painel.',
+            self::MANAGE_ROLES       => 'Montar os cargos: escolher o que cada um pode fazer.',
+            self::MANAGE_PERMISSIONS => 'Dar ou tirar um acesso avulso de uma pessoa, fora do cargo dela.',
+            self::ASSIGN_ROLES       => 'Trocar o cargo de outra pessoa.',
+            self::IMPERSONATE_USERS  => 'Entrar no painel como outra pessoa para reproduzir um problema.',
+        };
+    }
 }

--- a/app/Enum/Roles.php
+++ b/app/Enum/Roles.php
@@ -39,6 +39,24 @@ enum Roles: string
         };
     }
 
+    /**
+     * Uma linha sobre a quem atribuir o cargo — "Gerente" sozinho não diz.
+     *
+     * O texto descreve a matriz que o `PermissionRoleSeeder` semeia. Se você
+     * mudar quem recebe o quê, mude a frase junto: uma descrição desatualizada
+     * é pior que nenhuma, porque a pessoa decide por ela.
+     */
+    public function description(): string
+    {
+        return match ($this) {
+            self::SUPER_USER => 'Acesso total, inclusive às ferramentas de suporte. É o único cargo que age sobre outro igual ao seu.',
+            self::ADMIN      => 'Faz tudo no painel e cuida de quem entra. Não consegue usar o painel como outra pessoa.',
+            self::MANAGER    => 'Cuida da equipe: cadastra pessoas e troca o cargo delas. Não mexe no que cada cargo libera.',
+            self::VIEWER     => 'Entra no painel, mas nenhuma tela de gestão abre para ele. Use como base para um cargo de leitura que você montar.',
+            self::VISITOR    => 'Sem nenhum acesso. É onde a pessoa cai quando você remove o cargo dela.',
+        };
+    }
+
     public function priority(): int
     {
         return match ($this) {

--- a/app/Http/Controllers/PermissionRole/IndexController.php
+++ b/app/Http/Controllers/PermissionRole/IndexController.php
@@ -2,10 +2,11 @@
 
 namespace App\Http\Controllers\PermissionRole;
 
+use App\Enum\Roles as RolesEnum;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\RoleResource;
 use App\Http\Resources\UserResource;
-use App\Models\Permission;
+use App\Services\PermissionCatalogService;
 use App\Services\RoleFilterService;
 use Illuminate\Http\Request;
 use Inertia\Response;
@@ -13,7 +14,8 @@ use Inertia\Response;
 class IndexController extends Controller
 {
     public function __construct(
-        private readonly RoleFilterService $roleFilterService
+        private readonly RoleFilterService $roleFilterService,
+        private readonly PermissionCatalogService $permissionCatalog
     ) {
     }
 
@@ -33,8 +35,11 @@ class IndexController extends Controller
             ->mapWithKeys(function($role) {
                 return [
                     $role->name => [
-                        'id'          => $role->id,
-                        'label'       => $role->label ?? $role->name,
+                        'id'    => $role->id,
+                        'label' => $role->label ?? $role->name,
+                        // A descrição é do enum, não do banco: `roles` não tem
+                        // coluna para ela, e o enum é a fonte de verdade do RBAC.
+                        'description' => RolesEnum::tryFrom($role->name)?->description() ?? '',
                         'permissions' => $role->permissions->pluck('label', 'name'),
                         'users'       => UserResource::collection($role->users->keyBy->id),
                     ],
@@ -47,7 +52,7 @@ class IndexController extends Controller
         return inertia('permission-role/roles', [
             'roles'           => $roles,
             'assignableRoles' => $assignableRolesArray,
-            'permissions'     => Permission::all(),
+            'permissions'     => $this->permissionCatalog->forDisplay(),
         ]);
     }
 }

--- a/app/Http/Controllers/User/ShowUserPermissionsController.php
+++ b/app/Http/Controllers/User/ShowUserPermissionsController.php
@@ -6,8 +6,8 @@ namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\UserResource;
-use App\Models\Permission;
 use App\Models\User;
+use App\Services\PermissionCatalogService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
@@ -15,21 +15,22 @@ use Inertia\Response;
 
 final class ShowUserPermissionsController extends Controller
 {
+    public function __construct(
+        private readonly PermissionCatalogService $permissionCatalog
+    ) {
+    }
+
     public function __invoke(Request $request, User $user): Response
     {
         Gate::authorize('managePermissions', $user);
 
         $user->load(['role.permissions', 'permissions']);
 
-        $allPermissions = Permission::all()->map(fn($perm) => [
-            'id'    => $perm->id,
-            'name'  => $perm->name,
-            'label' => $perm->label,
-        ]);
-
         return Inertia::render('users/permissions', [
-            'user'            => new UserResource($user),
-            'all_permissions' => $allPermissions,
+            'user' => new UserResource($user),
+            // Mesmo catálogo da tela de cargos: o `PermissionCard` é o mesmo
+            // componente, e a decisão de dar um acesso avulso é a mesma decisão.
+            'all_permissions' => $this->permissionCatalog->forDisplay(),
         ]);
     }
 }

--- a/app/Services/PermissionCatalogService.php
+++ b/app/Services/PermissionCatalogService.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Services;
+
+use App\Enum\Permissions;
+use App\Models\Permission;
+
+/**
+ * O catálogo de permissões como as telas de RBAC precisam dele: na ordem em que
+ * o enum declara, com o label e a descrição vindos do enum, e **só** o que
+ * existe no banco.
+ *
+ * As duas pontas importam. O enum é a fonte de verdade do texto — mudar uma
+ * palavra passa a valer na hora, sem esperar `permissions:sync`. Mas o banco é
+ * quem decide o que pode ser marcado: `UpdateRolePermissionsRequest` valida com
+ * `exists:permissions,name`, então oferecer um caso do enum ainda não semeado
+ * seria oferecer uma caixa que o save recusa.
+ */
+final class PermissionCatalogService
+{
+    /**
+     * @return list<array{name: string, label: string, description: string}>
+     */
+    public function forDisplay(): array
+    {
+        $stored = Permission::query()->pluck('name')->flip();
+
+        return collect(Permissions::cases())
+            ->filter(fn(Permissions $case): bool => $stored->has($case->value))
+            ->map(fn(Permissions $case): array => [
+                'name'        => $case->value,
+                'label'       => $case->label(),
+                'description' => $case->description(),
+            ])
+            ->values()
+            ->all();
+    }
+}

--- a/resources/js/components/permissions/permission-card.tsx
+++ b/resources/js/components/permissions/permission-card.tsx
@@ -29,7 +29,7 @@ export function PermissionCard({ permission, isChecked, onToggle }: PermissionCa
                     'dark:border-foreground/30 dark:bg-card dark:data-[state=unchecked]:bg-card',
                     'border-foreground/20',
                 )}
-                aria-label={`Permissão: ${permission.label}`}
+                aria-label={`${permission.label}: ${permission.description}`}
             />
             <div className="flex-1">
                 <div className="flex items-center gap-2">
@@ -41,6 +41,11 @@ export function PermissionCard({ permission, isChecked, onToggle }: PermissionCa
                     />
                     <span className="dark:text-foreground text-sm font-medium">{permission.label}</span>
                 </div>
+                {/* A frase é o que decide a marcação — o nome sozinho confunde
+                    "Gerenciar Permissões" com "Atribuir Cargos". */}
+                {permission.description && (
+                    <p className="text-muted-foreground dark:text-muted-foreground/80 mt-1 pl-6 text-xs leading-relaxed">{permission.description}</p>
+                )}
             </div>
         </label>
     );

--- a/resources/js/pages/permission-role/roles.tsx
+++ b/resources/js/pages/permission-role/roles.tsx
@@ -182,11 +182,13 @@ export default function Roles({ roles, assignableRoles = [], permissions }: Perm
                                                 {selectedRoleData.label}
                                             </h2>
                                         </div>
-                                        <div className="mt-1 flex flex-wrap items-center gap-2 sm:gap-3">
-                                            <p className="text-muted-foreground dark:text-muted-foreground/70 text-xs sm:text-sm">
-                                                Quem tem este cargo passa a poder fazer o que estiver marcado abaixo
+                                        {/* A quem este cargo se destina. "Gerente" sozinho não diz. */}
+                                        {selectedRoleData.description && (
+                                            <p className="text-muted-foreground dark:text-muted-foreground/70 mt-1 text-xs sm:text-sm">
+                                                {selectedRoleData.description}
                                             </p>
-                                            <span className="text-muted-foreground dark:text-muted-foreground/50 hidden text-xs sm:inline">•</span>
+                                        )}
+                                        <div className="mt-1 flex flex-wrap items-center gap-2 sm:gap-3">
                                             <span className="text-muted-foreground dark:text-muted-foreground/70 text-xs">
                                                 {Object.keys(selectedRoleData.permissions || {}).length}{' '}
                                                 {Object.keys(selectedRoleData.permissions || {}).length === 1 ? 'permissão' : 'permissões'} vinculada

--- a/resources/js/pages/users/permissions.tsx
+++ b/resources/js/pages/users/permissions.tsx
@@ -4,7 +4,8 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { useFlashMessages } from '@/hooks/use-flash-messages';
 import AppLayout from '@/layouts/app-layout';
-import { BreadcrumbItem, Permission, User } from '@/types';
+import { BreadcrumbItem, User } from '@/types';
+import type { PermissionOption } from '@/types/permissions';
 import { Head, Link, router } from '@inertiajs/react';
 import { ArrowLeft, Edit, Save, Shield, User2 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
@@ -33,7 +34,7 @@ interface UserPermissionsProps {
             }>;
         };
     };
-    all_permissions: Permission[];
+    all_permissions: PermissionOption[];
 }
 
 export default function UserPermissions({ user, all_permissions }: UserPermissionsProps) {

--- a/resources/js/test/components/permissions/permission-card.test.tsx
+++ b/resources/js/test/components/permissions/permission-card.test.tsx
@@ -1,0 +1,38 @@
+import { PermissionCard } from '@/components/permissions/permission-card';
+import type { PermissionOption } from '@/types/permissions';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+const permission: PermissionOption = {
+    name: 'manage_permissions',
+    label: 'Gerenciar Permissões',
+    description: 'Dar ou tirar um acesso avulso de uma pessoa, fora do cargo dela.',
+};
+
+describe('PermissionCard', () => {
+    // O nome sozinho confunde "Gerenciar Permissões" com "Atribuir Cargos" —
+    // a frase é o que decide a marcação.
+    it('shows what the permission lets the person do', () => {
+        render(<PermissionCard permission={permission} isChecked={false} onToggle={vi.fn()} />);
+
+        expect(screen.getByText(permission.label)).toBeInTheDocument();
+        expect(screen.getByText(permission.description)).toBeInTheDocument();
+    });
+
+    it('announces label and consequence together to screen readers', () => {
+        render(<PermissionCard permission={permission} isChecked={false} onToggle={vi.fn()} />);
+
+        expect(screen.getByRole('checkbox')).toHaveAccessibleName(`${permission.label}: ${permission.description}`);
+    });
+
+    it('reports the toggle by permission name', async () => {
+        const onToggle = vi.fn();
+
+        render(<PermissionCard permission={permission} isChecked={false} onToggle={onToggle} />);
+
+        await userEvent.click(screen.getByRole('checkbox'));
+
+        expect(onToggle).toHaveBeenCalledWith(permission.name, true);
+    });
+});

--- a/resources/js/types/permissions.ts
+++ b/resources/js/types/permissions.ts
@@ -1,12 +1,25 @@
-import { Permission, Role, User } from './index';
+import { Role, User } from './index';
 
 /**
  * Tipos relacionados ao módulo de Permissões
  */
 
+/**
+ * Uma permissão como as telas de RBAC a recebem: espelha
+ * `PermissionCatalogService::forDisplay()`. Label e descrição vêm do enum
+ * `App\Enum\Permissions`, não das colunas do banco — os dois mudam juntos.
+ */
+export type PermissionOption = {
+    name: string;
+    label: string;
+    description: string;
+};
+
 export type RoleData = {
     id: number;
     label: string;
+    /** Vem de `App\Enum\Roles::description()`; `roles` não tem coluna para ela. */
+    description: string;
     permissions: Record<string, string>; // permission name -> permission label
     users: User[] | Record<number, User>; // Array ou objeto keyed por id
 };
@@ -14,7 +27,7 @@ export type RoleData = {
 export type RolesData = Record<string, RoleData>; // role name -> role data
 
 export type PermissionCardProps = {
-    permission: Permission;
+    permission: PermissionOption;
     isChecked: boolean;
     onToggle: (permissionName: string, checked: boolean) => void;
 };
@@ -35,7 +48,7 @@ export type RoleInfoDialogProps = {
 export type PermissionsPageProps = {
     roles: RolesData;
     assignableRoles?: Role[];
-    permissions: Permission[];
+    permissions: PermissionOption[];
 };
 
 export type PermissionActionHandlers = {

--- a/tests/Feature/CopyPainelTest.php
+++ b/tests/Feature/CopyPainelTest.php
@@ -33,11 +33,13 @@ test('no visible label falls back to the abandoned terms', function(): void {
     }
 });
 
-test('seeding carries the enum label into the database the screen reads', function(): void {
-    // A tela de cargos monta os cards com `permissions.label` vindo do BANCO
-    // (`PermissionRole/IndexController`), não do enum. Trocar a palavra no enum
-    // só aparece depois de `php artisan permissions:sync` — ou de um deploy que
-    // rode o seeder.
+test('seeding carries the enum label into the database', function(): void {
+    // As telas de RBAC passaram a ler label e descrição do enum, via
+    // `PermissionCatalogService` — lá a palavra nova vale na hora. Mas a coluna
+    // `permissions.label` continua sendo a fonte de outros pontos (as
+    // permissões avulsas do usuário, por `getCustomPermissionsList()`), e quem
+    // a atualiza é o seeder. Sem `php artisan permissions:sync`, esses pontos
+    // seguem mostrando a palavra antiga.
     $this->seed(Database\Seeders\PermissionRoleSeeder::class);
 
     $label = App\Models\Permission::query()

--- a/tests/Feature/PermissionRole/PermissionCatalogTest.php
+++ b/tests/Feature/PermissionRole/PermissionCatalogTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Enum\Permissions;
+use App\Enum\Roles;
+use App\Models\Permission;
+use App\Services\PermissionCatalogService;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/*
+ * O catálogo que as duas telas de RBAC consomem. Label e descrição vêm do enum;
+ * o banco decide o que pode ser marcado. As duas pontas importam, e cada uma
+ * quebra de um jeito diferente.
+ */
+
+it('describes every permission and every role', function(): void {
+    // Uma descrição vazia é pior que nenhuma coluna: a tela renderiza um espaço
+    // em branco onde a pessoa esperava a explicação para decidir.
+    foreach (Permissions::cases() as $permission) {
+        expect($permission->description())->not->toBe('');
+    }
+
+    foreach (Roles::cases() as $role) {
+        expect($role->description())->not->toBe('');
+    }
+});
+
+it('lists permissions in the order the enum declares them', function(): void {
+    // `Permission::all()` devolvia na ordem do banco, que é a de inserção do
+    // seeder por acidente — nada garantia que continuasse assim.
+    $this->seed(Database\Seeders\PermissionRoleSeeder::class);
+
+    $names = array_column(app(PermissionCatalogService::class)->forDisplay(), 'name');
+
+    expect($names)->toBe(array_map(
+        fn(Permissions $case): string => $case->value,
+        Permissions::cases()
+    ));
+});
+
+it('takes label and description from the enum, not from the database columns', function(): void {
+    // Sem isso, trocar uma palavra no enum só apareceria na tela depois de
+    // `php artisan permissions:sync`.
+    $this->seed(Database\Seeders\PermissionRoleSeeder::class);
+
+    Permission::query()
+        ->where('name', Permissions::MANAGE_USERS->value)
+        ->update(['label' => 'Rótulo velho do banco']);
+
+    $entry = collect(app(PermissionCatalogService::class)->forDisplay())
+        ->firstWhere('name', Permissions::MANAGE_USERS->value);
+
+    expect($entry['label'])->toBe(Permissions::MANAGE_USERS->label())
+        ->and($entry['label'])->not->toBe('Rótulo velho do banco')
+        ->and($entry['description'])->toBe(Permissions::MANAGE_USERS->description());
+});
+
+it('omits an enum case that is not seeded yet', function(): void {
+    // O save valida com `exists:permissions,name`: oferecer uma caixa que o
+    // banco ainda não conhece seria oferecer uma caixa que o save recusa.
+    $this->seed(Database\Seeders\PermissionRoleSeeder::class);
+
+    $impersonate = Permission::query()->where('name', Permissions::IMPERSONATE_USERS->value)->firstOrFail();
+
+    // `permission_role` tem FK para as duas pontas — mesma ordem do
+    // SyncPermissionsCommand ao remover uma permissão órfã.
+    DB::table('permission_role')->where('permission_id', $impersonate->id)->delete();
+    $impersonate->delete();
+
+    $names = array_column(app(PermissionCatalogService::class)->forDisplay(), 'name');
+
+    expect($names)->not->toContain(Permissions::IMPERSONATE_USERS->value)
+        ->and($names)->toContain(Permissions::MANAGE_USERS->value);
+});
+
+it('ships the catalog and the role descriptions to the roles screen', function(): void {
+    actingAsSuperUser();
+
+    $this->get(route('role-permissions'))
+        ->assertOk()
+        ->assertInertia(fn(Assert $page) => $page
+            ->component('permission-role/roles')
+            ->has('permissions', count(Permissions::cases()))
+            ->where('permissions.0.name', Permissions::MANAGE_USERS->value)
+            ->where('permissions.0.description', Permissions::MANAGE_USERS->description())
+            ->where('roles.' . Roles::MANAGER->value . '.description', Roles::MANAGER->description()));
+});
+
+it('ships the same catalog to the individual permissions screen', function(): void {
+    // `PermissionCard` é o mesmo componente nas duas telas: se um dos payloads
+    // ficasse para trás, uma delas renderizaria card sem descrição.
+    actingAsSuperUser();
+    $target = guestUser();
+
+    $this->get(route('users.permissions.show', $target))
+        ->assertOk()
+        ->assertInertia(fn(Assert $page) => $page
+            ->component('users/permissions')
+            ->has('all_permissions', count(Permissions::cases()))
+            ->where('all_permissions.0.description', Permissions::MANAGE_USERS->description()));
+});


### PR DESCRIPTION
Fecha #42. Harvest reversa do `spinmax` — PR D de cinco.

## O que estava faltando

A tela de cargos mostrava cinco checkboxes com o nome da permissão e nada mais. "Gerenciar Permissões" e "Atribuir Cargos" são parecidos o bastante para serem trocados um pelo outro por quem está montando um cargo. E "Gerente" sozinho não diz a quem atribuir.

`description()` nos dois enums — uma frase por caso, escrita em **consequência**, não em nome de tela.

## As permissões portaram literais; os cargos não

As 5 permissões são idênticas nos dois repositórios e nenhuma descrição do `spinmax` cita a loja — vieram como estão.

Os cargos precisaram de redação nova: o `spinmax` tem `OPERATIONS`/`ACCOUNTING` onde aqui existe `MANAGER`, e o texto do `SUPER_USER` dele nomeia o cliente ("Equipe da Simplify"), o que não cabe num boilerplate.

As frases descrevem a matriz que o `PermissionRoleSeeder` semeia — inclusive o que ela tem de desconfortável:

- **`VIEWER` e `VISITOR` têm zero permissões.** Descrever o Visualizador como "só olha", que é o que o `spinmax` faz, seria mais uma promessa falsa do tipo que o PR C acabou de tirar do painel: nenhuma tela de gestão abre para ele. O que separa os dois é a prioridade e o `VISITOR` ser o destino do revoke — é isso que as descrições dizem.
- **`ADMIN` tem tudo menos `impersonate_users`**, de propósito. A frase diz isso.
- **`SUPER_USER` é o único cargo que age sobre outro igual ao seu** — consequência direta do teto do PR A.

Se a matriz mudar, a frase muda junto. Uma descrição desatualizada é pior que nenhuma, porque a pessoa decide por ela; deixei isso escrito no docblock do enum.

## Levando até a tela

`PermissionCatalogService` monta o catálogo na ordem em que o enum declara, com label e descrição vindos do enum e **só** o que existe no banco. As duas pontas importam, e cada uma quebra de um jeito diferente:

- **enum como fonte do texto** — trocar uma palavra passa a valer na hora, sem esperar `permissions:sync`. `Permission::all()` devolvia na ordem do banco, que era a de inserção do seeder por acidente;
- **banco como fonte do que existe** — `UpdateRolePermissionsRequest` valida com `exists:permissions,name`, então oferecer um caso do enum ainda não semeado seria oferecer uma caixa que o save recusa.

`PermissionCard` é o mesmo componente na tela de cargos e na de permissões avulsas, então **os dois payloads mudaram juntos** — deixar um para trás renderizaria card sem descrição. Isso trouxe `ShowUserPermissionsController` para o PR; não é escopo extra, é o que a mudança exige.

A descrição do cargo entra no `roles` do payload (a tabela `roles` não tem coluna para ela) e substitui, no cabeçalho, a frase genérica sobre a tela que o PR C tinha posto ali: o espaço rende mais dizendo a quem o cargo se destina, e a explicação da tela já existe logo abaixo, na seção de permissões.

## Testes

`tests/Feature/PermissionRole/PermissionCatalogTest.php` (6) — os 6 falham sem a mudança:

- toda permissão e todo cargo têm descrição não vazia (uma string vazia renderiza um espaço em branco onde a pessoa esperava a explicação)
- a ordem é a de declaração do enum
- label e descrição vêm do enum mesmo com a coluna do banco divergente
- um caso do enum ainda não semeado **não** aparece
- as duas telas recebem o mesmo catálogo, com as descrições

`permission-card.test.tsx` (3) — a frase renderiza, o checkbox anuncia label + consequência juntos para leitor de tela, e o toggle segue reportando por `name`.

### Um comentário do PR C ficou desatualizado

O `CopyPainelTest` dizia que a tela lê `permissions.label` do banco. Depois deste PR ela lê do enum. O teste continua válido — a coluna ainda alimenta outros pontos, como as permissões avulsas via `getCustomPermissionsList()` —, mas o comentário foi corrigido para não mentir sobre o motivo.

## Gates

- `composer ci:check` — Pint, Rector, larastan, 293 testes ✅
- `corepack pnpm ci:check` — ESLint, Prettier, tsc, 150 Vitest, build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)