### PR TITLE
[48] docs(migration): registra no transitado o que a harvest reversa apagou

### DIFF
--- a/docs/migration/projects/transitado-em-julgado.md
+++ b/docs/migration/projects/transitado-em-julgado.md
@@ -106,4 +106,15 @@ Ordem recomendada: **0 → 1 → 2 → 4 → 5 → 6** (3a/3b puladas).
 - **Drift descoberto p/ resync da Fatia 6:** Form Requests de `Musicas/` autorizam `true` (User/PermissionRole re-checam `can()` — a convenção em camadas); requests usam a string `'manage_users'` em vez do enum `Permissions`.
 - Gates verdes antes e depois: `composer ci:check` e `pnpm ci:check` (este, após a válvula do nanoid).
 
+**Drift criado pelo boilerplate depois da Fatia 1 (harvest reversa do spinmax, 2026-08-11) — resolver na Fatia 6:**
+
+A Fatia 1 zerou o passivo do Larastan portando tipagem de arquivos de origem comum. Dois deles **deixaram de existir no boilerplate** desde então:
+
+- **`app/DataTransferObjects/PermissionMetaDTO.php` foi apagado** (PR #45). Era código morto lá: o único hit no repositório era a própria declaração, e `HasRolesAndPermissions::getCustomPermissionsList()` remonta a mesma forma inline. Aqui ele chegou como material de tipagem, não por uso — conferir se algum ponto do transitado passou a consumi-lo de verdade antes de apagar. Atenção: a regra de arch local ("`App\DataTransferObjects` readonly") ficaria sem alvo se este for o único DTO do projeto.
+- **`Roles::options()` foi apagado** (mesmo PR). Zero call sites no boilerplate, e devolvia `super_user` e `visitor` crus para um `<select>` que ignora o `RoleFilterService`. Aqui ele aparece na lista de "domínio próprio anotado à mão" da Fatia 1 — verificar se tem consumidor real antes de remover.
+
+No mesmo lote o boilerplate ganhou `Roles::isSelectable()` (tira "Visitante" do seletor de atribuição, **só na exibição**), `User::permissionCacheKey()` (a chave estava escrita à mão em 7 pontos) e `Cache::forget` no `PermissionRoleSeeder`. Os três entram junto no resync do RBAC.
+
+Também **saíram do boilerplate** `lang/pt_BR.json`, `lang/pt_BR/actions.php` e `lang/pt_BR/http-statuses.php` (zero referências). O §3 acima registra "sem `lang/`" como gap deste projeto: quando a fatia de i18n rodar, o alvo a copiar é `auth.php`, `pagination.php`, `passwords.php` e `validation.php` — **não** mais o `pt_BR.json`.
+
 Última atualização: 2026-08-10 (alvo re-congelado pós-update de deps; Fatia 2 concluída — próxima: Fatia 4 — Hardening + smoke browser adiado da Fatia 1)


### PR DESCRIPTION
Closes #48. Fecha a harvest reversa do `spinmax` (#36–#45) pelo lado da documentação.

**Uma adição de 11 linhas, zero remoções, um arquivo.**

## O problema

A Fatia 1 do transitado-em-julgado zerou o passivo do Larastan **portando tipagem de arquivos de origem comum do boilerplate**. Dois deles deixaram de existir aqui no #45, por serem código morto:

- `app/DataTransferObjects/PermissionMetaDTO.php`
- `Roles::options()`

O gap-report daquele projeto ainda os lista como material da Fatia 1 (`:94`). Sem o registro, a Fatia 6 chega sem saber se remove, mantém ou trata como divergência deliberada.

## A nota diz o que conferir, não o que fazer

Nenhum dos dois foi apagado por estar **errado** — foram apagados por não terem consumidor **no boilerplate**. No derivado isso precisa ser verificado, não presumido: a nota manda conferir antes de remover, e avisa que a regra de arch local (`App\DataTransferObjects` readonly) ficaria sem alvo se o `PermissionMetaDTO` for o único DTO de lá.

Registra também o que entra junto no resync do RBAC (`Roles::isSelectable()`, `User::permissionCacheKey()`, `Cache::forget` no seeder) e corrige uma expectativa que ficou obsoleta: o §3 do gap-report trata "sem `lang/`" como gap a preencher copiando do boilerplate — e o `pt_BR.json` não está mais lá para ser copiado.

É a contraparte da §4 que o `spinmax.md` ganhou no #45: lá o drift **bidirecional**, aqui o **unidirecional** que a harvest criou.

## Por que veio num PR separado

O #45 já trazia esta nota pronta, mas o `transitado-em-julgado.md` está com alterações não commitadas da Fatia 2b no working tree, e a adição cai no mesmo hunk. Absorver aquele trabalho numa mensagem de commit minha seria atribuição errada, então saiu do #45 e virou este PR, aplicado sobre a versão limpa do arquivo.

**As alterações da Fatia 2b seguem intactas e não commitadas** — este PR não toca nenhuma linha delas. Ao mergear, o rebase local vai reaplicar as suas por cima sem conflito, já que os dois blocos são adjacentes mas disjuntos.

## Gates

Mudança só de documentação; `composer ci:check` e `corepack pnpm ci:check` rodaram verdes no pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)