### PR TITLE
[53]: test(inertia): trava o shape das props globais e reconcilia o espelho TS

### DIFF
--- a/resources/js/hooks/use-flash-messages.tsx
+++ b/resources/js/hooks/use-flash-messages.tsx
@@ -1,14 +1,8 @@
 import { toastErrorOptions, toastInfoOptions, toastSuccessOptions, toastWarningOptions } from '@/lib/toast-config';
+import type { FlashMessages } from '@/types';
 import { usePage } from '@inertiajs/react';
 import { useEffect, useRef } from 'react';
 import toast from 'react-hot-toast';
-
-interface FlashMessages {
-    success?: string;
-    error?: string;
-    warning?: string;
-    info?: string;
-}
 
 interface WindowWithFlashCleanup extends Window {
     __flashCleanupInterval?: ReturnType<typeof setInterval>;

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -49,12 +49,39 @@ export interface NavItem {
     role?: string;
 }
 
+/**
+ * Mensagens de uma ação, consumidas por `useFlashMessages`. Espelha o bloco
+ * `flash` de `HandleInertiaRequests::share()` — as quatro chaves vêm sempre,
+ * com `null` quando não há mensagem.
+ */
+export interface FlashMessages {
+    success: string | null;
+    error: string | null;
+    warning: string | null;
+    info: string | null;
+}
+
+/**
+ * Props globais que toda página recebe. Espelha `HandleInertiaRequests::share()`
+ * — os dois mudam juntos, e `tests/Feature/SharedPropsTest.php` trava o shape
+ * dos dois lados.
+ *
+ * `errors` não vem do `share()`: o middleware do Inertia injeta em toda
+ * resposta. Está aqui porque o tipo descreve o que a página RECEBE.
+ */
 export interface SharedData {
+    errors: Record<string, string>;
     name: string;
     quote: { message: string; author: string };
     auth: Auth;
+    flash: FlashMessages;
     ziggy: Config & { location: string };
 
+    // Exigido pelo constraint `PageProps` do @inertiajs/react: sem o index
+    // signature, `usePage<SharedData>()` não compila. Ou seja, o tipo é
+    // necessariamente mais largo que o payload e NÃO consegue barrar prop
+    // global nova sozinho — quem barra é o contrato de runtime em
+    // tests/Feature/SharedPropsTest.php. Não remova achando que é desleixo.
     [key: string]: unknown;
 }
 

--- a/tests/Feature/SharedPropsTest.php
+++ b/tests/Feature/SharedPropsTest.php
@@ -12,6 +12,47 @@ use Inertia\Testing\AssertableInertia as Assert;
  * tipos em resources/js/types — os dois mudam juntos.
  */
 
+it('trava o conjunto inteiro de props globais que toda página recebe', function(): void {
+    // `interacted()` é o que transforma isto num contrato: ao fechar o escopo,
+    // chave que ninguém tocou falha com "Unexpected properties were found in
+    // scope". Assim, chave nova no share() sem espelho em resources/js/types
+    // quebra aqui.
+    //
+    // O `->interacted()` do fim NÃO é redundante: o AssertableInertia aplica a
+    // checagem automaticamente só nos escopos aninhados (os `has()` com
+    // callback). No escopo raiz ela não roda sozinha — sem esta linha, uma prop
+    // global nova passa despercebida, que é exatamente o buraco que este teste
+    // existe para fechar.
+    //
+    // `errors` não sai do share(): o middleware do Inertia injeta em toda
+    // resposta. Está no contrato porque ele descreve o que a PÁGINA recebe.
+    actingAsSuperUser();
+
+    $this->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn(Assert $page) => $page
+            ->has('errors')
+            ->has('name')
+            ->has('quote', fn(Assert $quote) => $quote
+                ->has('message')
+                ->has('author'))
+            ->has('auth', fn(Assert $auth) => $auth
+                ->has('user')
+                ->has('permissions')
+                ->has('roles')
+                ->has('impersonating', fn(Assert $impersonating) => $impersonating
+                    ->has('active')
+                    ->has('originalUserName')
+                    ->has('impersonatedUserName')))
+            ->has('flash', fn(Assert $flash) => $flash
+                ->has('success')
+                ->has('error')
+                ->has('warning')
+                ->has('info'))
+            ->has('ziggy')
+            ->interacted());
+});
+
 it('shares only the fields the front actually reads from the authenticated user', function(): void {
     // O $hidden do model esconde só password e remember_token: compartilhar o
     // model inteiro mandava cpf_cnpj, phone, mobile e user_notes em toda página.


### PR DESCRIPTION
Closes #53

## Por quê

`HandleInertiaRequests::share()` é a fonte única das props globais, e o que sai dali viaja em **toda** navegação do painel. O `SharedPropsTest` cobria o interior de `auth.user` e mais nada — chave nova, ou chave que sumisse, passava sem gate.

## O que entra

### 1. O contrato de runtime

O teste agora toca as **6** chaves do topo, as 4 de `auth`, as 4 de `flash` e as 3 de `impersonating`, e fecha com `interacted()`.

Duas coisas que só apareceram medindo, e que valem a revisão:

- **O `->interacted()` explícito no fim não é enfeite.** O `AssertableInertia` aplica a checagem automaticamente só nos escopos aninhados (os `has()` com callback). No escopo raiz ela não roda sozinha. Descobri por mutação: com uma chave `telemetry` inventada no topo do `share()`, o teste passava verde. Sem essa linha o guard nasceria meio cego, justamente no nível que ele existe para proteger.
- **O topo tem 6 chaves, não 5.** `errors` é injetado pelo middleware do Inertia 3, não pelo `share()`. Entrou no contrato porque ele descreve o que a página **recebe**.

### 2. A outra ponta do mesmo fio

`flash` era publicado pelo `share()` e **não existia em `SharedData`**: o shape vivia numa interface privada `FlashMessages` dentro de `use-flash-messages.tsx`. É o "segundo canal com shape diferente para os mesmos dados" que o `CLAUDE.md` proíbe. Agora é um tipo só, exportado de `@/types` e consumido pelo hook.

### 3. Uma nota que evita um refactor errado no futuro

Tentei remover o `[key: string]: unknown` de `SharedData` — é ele que deixa o tipo mais largo que o payload. **Não dá:** é exigência do constraint `PageProps` do `@inertiajs/react`, e sem ele `usePage<SharedData>()` quebra em 7 arquivos (`TS2344`). O comentário no código registra isso, com a consequência: o tipo não consegue barrar prop global nova sozinho — quem barra é o teste de runtime.

## Verificação

Verificado por mutação, nas três direções:

| Mutação | Resultado |
| ------- | --------- |
| Chave nova no topo do `share()` (`telemetry`) | ⨯ `Unexpected properties were found on the root level` |
| Chave nova dentro de `auth` (`subscription`) | ⨯ `Unexpected properties were found in scope [auth]` |
| Chave removida de `flash` (`warning`) | ⨯ `Property [flash.warning] does not exist` |

Gates: `composer ci:check` e `corepack pnpm ci:check` verdes, ambos exit 0. O `pre-push` rodou os dois.

## Rastreabilidade

`harvest: ctfinance resources/js/types/index.d.ts@b8c6d57` — rodada Harvest v2, dimensão 2 (Arquitetura), candidato A3. O ctfinance tipa `Auth.user` como o `User` inteiro; o mecanismo `interacted()` veio da lente de atualidade, e a contagem correta do topo veio da lente de risco, que previu que o conjunto proposto nasceria vermelho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
