### PR TITLE
[57]: fix(impersonation): invalida o cache de prefetch ao trocar de identidade

### DIFF
--- a/.ai/rules/js.md
+++ b/.ai/rules/js.md
@@ -17,5 +17,8 @@ Cada página Inertia chama useFlashMessages() no topo do componente — o hook e
 ## Tabelas com Table de @radix-ui/themes, não shadcn
 Construa tabelas de listagem (e Box/Flex/Tabs dessas telas) com @radix-ui/themes — o app já é envolvido em <Theme>; não use o components/ui/table.tsx do shadcn, que existe mas não é adotado.
 
+## Troca de identidade invalida o cache de prefetch
+Iniciar e encerrar impersonation passa por startImpersonation/stopImpersonation de lib/impersonation.ts, que chamam router.flushAll() antes da visita; não chame router.post/delete com as rotas users.impersonate direto, mesmo que pareça uma linha só. O cache de prefetch do Inertia guarda respostas por URL sem noção de quem estava autenticado, os controllers devolvem 302 (não Inertia::location()), e o default do framework só invalida a URL de destino — sem o flush, uma página prefetchada com o admin logado é servida durante a personificação. Use flushAll e não cacheTags/invalidateCacheTags para escopo de identidade: tag esquecida em um Link falha aberto e vaza em silêncio, enquanto flushAll no máximo refaz alguns prefetches. Dois testes em resources/js/test/lib/ travam o contrato, incluindo a proibição de nomear as rotas fora do módulo.
+
 ## Textos de UI em português hardcoded
 O frontend é monolíngue pt_BR: escreva textos de UI (páginas React, labels, mensagens) diretamente em português, sem biblioteca de i18n nem chaves JSON.

--- a/resources/js/components/impersonate-banner.tsx
+++ b/resources/js/components/impersonate-banner.tsx
@@ -1,4 +1,4 @@
-import { router } from '@inertiajs/react';
+import { stopImpersonation as stopImpersonationVisit } from '@/lib/impersonation';
 import type { MouseEvent } from 'react';
 
 interface ImpersonateBannerProps {
@@ -14,7 +14,7 @@ export function ImpersonateBanner({ active, originalUserName, impersonatedUserNa
 
     const stopImpersonation = (e: MouseEvent<HTMLAnchorElement>) => {
         e.preventDefault();
-        router.delete(route('users.impersonate.stop'));
+        stopImpersonationVisit();
     };
 
     // Mostra o nome de quem está sendo usado como persona (não quem entrou)

--- a/resources/js/components/user-details-dialog.tsx
+++ b/resources/js/components/user-details-dialog.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Separator } from '@/components/ui/separator';
+import { startImpersonation } from '@/lib/impersonation';
 import { router } from '@inertiajs/react';
 import { Calendar, Eye, Key, Mail, Phone, Settings, Shield, User, UserCheck } from 'lucide-react';
 import { useState } from 'react';
@@ -46,18 +47,14 @@ export function UserDetailsDialog({ open, onOpenChange, user, canManagePermissio
 
     const handleImpersonate = () => {
         setIsImpersonating(true);
-        router.post(
-            route('users.impersonate', user.id),
-            {},
-            {
-                onSuccess: () => {
-                    // Redirect will happen automatically
-                },
-                onError: () => {
-                    setIsImpersonating(false);
-                },
+        startImpersonation(user.id, {
+            onSuccess: () => {
+                // Redirect will happen automatically
             },
-        );
+            onError: () => {
+                setIsImpersonating(false);
+            },
+        });
     };
 
     const handleManagePermissions = () => {

--- a/resources/js/hooks/users/use-user-actions.ts
+++ b/resources/js/hooks/users/use-user-actions.ts
@@ -1,3 +1,4 @@
+import { startImpersonation } from '@/lib/impersonation';
 import type { User, UserActionHandlers } from '@/types/users';
 import { router } from '@inertiajs/react';
 import { useCallback } from 'react';
@@ -49,7 +50,7 @@ export function useUserActions(options: UseUserActionsOptions = {}): UserActionH
     );
 
     const handleImpersonate = useCallback((user: User) => {
-        router.post(route('users.impersonate', user.id), {});
+        startImpersonation(user.id);
     }, []);
 
     const handleAssignRole = useCallback(() => {

--- a/resources/js/lib/impersonation.ts
+++ b/resources/js/lib/impersonation.ts
@@ -1,0 +1,46 @@
+import { router } from '@inertiajs/react';
+
+/**
+ * Troca de identidade — o único caminho para iniciar e encerrar impersonation.
+ *
+ * Existe para que seja impossível trocar de identidade sem invalidar o cache de
+ * prefetch. O painel tem 6 superfícies com `<Link prefetch>` (nav-main,
+ * app-sidebar, app-header, user-menu-content, settings-sidebar e o layout de
+ * settings), e o Inertia guarda essas respostas por URL, sem qualquer noção de
+ * quem estava autenticado quando foram buscadas.
+ *
+ * O default do framework NÃO cobre este caso. Depois de uma visita bem-sucedida
+ * o core (@inertiajs/core 3.6.1) só invalida a URL de destino e as tags que a
+ * visita declarou — nada mais. E os dois controllers de impersonation devolvem
+ * `RedirectResponse` puro (302), não `Inertia::location()`, então a SPA não
+ * reinicia: o cache atravessa a troca inteiro.
+ *
+ * Sem o flush, um prefetch de `/settings/profile` feito com o admin logado
+ * continua no cache e é servido no clique seguinte — mostrando nome e e-mail do
+ * admin enquanto se personifica outro usuário.
+ *
+ * Por que `flushAll()` e não `cacheTags`/`invalidateCacheTags`, que são a forma
+ * idiomática na v3: modo de falha. Invalidação por tag falha ABERTO — basta
+ * esquecer a tag em um dos `<Link prefetch>`, ou no próximo que alguém
+ * acrescentar, e dado de outra identidade volta a ser servido em silêncio.
+ * `flushAll()` falha FECHADO: o pior caso é refazer alguns prefetches, num
+ * momento raro. Trocar de identidade invalida semanticamente toda página
+ * cacheada, então jogar tudo fora é a operação certa, não um exagero.
+ *
+ * A ordem (flush antes da visita) é por simplicidade, não por corrida: o cache
+ * só é consultado quando uma nova visita é iniciada, e o 302 é seguido na
+ * camada HTTP sem passar por ali.
+ */
+
+type StartOptions = Parameters<typeof router.post>[2];
+type StopOptions = Parameters<typeof router.delete>[1];
+
+export function startImpersonation(userId: number | string, options: StartOptions = {}): void {
+    router.flushAll();
+    router.post(route('users.impersonate', userId), {}, options);
+}
+
+export function stopImpersonation(options: StopOptions = {}): void {
+    router.flushAll();
+    router.delete(route('users.impersonate.stop'), options);
+}

--- a/resources/js/test/lib/impersonation-call-sites.test.ts
+++ b/resources/js/test/lib/impersonation-call-sites.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/*
+ * A outra metade da defesa de lib/impersonation.ts.
+ *
+ * O módulo garante que quem passa por ele invalida o cache de prefetch. Só que
+ * isso não impede ninguém de chamar `router.post(route('users.impersonate'))`
+ * direto e reabrir o buraco — foi exatamente assim que os três call sites
+ * existentes nasceram, cada um numa data, nenhum sabendo do outro.
+ *
+ * Então o contrato é: as rotas de impersonation só são nomeadas dentro do
+ * módulo. Uma quarta tela que precise trocar de identidade importa
+ * startImpersonation/stopImpersonation e herda o flush de graça.
+ */
+
+const jsRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+const OWNER = 'lib/impersonation.ts';
+
+/**
+ * Arquivos de aplicação: tudo em resources/js exceto os próprios testes.
+ */
+function applicationSourceFiles(dir: string = jsRoot): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const full = join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            return entry.name === 'test' ? [] : applicationSourceFiles(full);
+        }
+
+        return /\.tsx?$/.test(entry.name) ? [full] : [];
+    });
+}
+
+it('actually reads the frontend source tree', () => {
+    expect(applicationSourceFiles().length).toBeGreaterThan(50);
+});
+
+describe('impersonation route ownership', () => {
+    it('keeps the impersonation routes named only inside the module that flushes the cache', () => {
+        const offenders = applicationSourceFiles()
+            .map((path) => ({ path: relative(jsRoot, path), body: readFileSync(path, 'utf8') }))
+            .filter(({ path, body }) => path !== OWNER && body.includes('users.impersonate'))
+            .map(({ path }) => path);
+
+        expect(offenders).toEqual([]);
+    });
+
+    it('keeps the module itself flushing the cache', () => {
+        const body = readFileSync(join(jsRoot, OWNER), 'utf8');
+
+        expect(body).toContain('router.flushAll()');
+        expect(body.match(/router\.flushAll\(\)/g)).toHaveLength(2);
+    });
+});

--- a/resources/js/test/lib/impersonation.test.tsx
+++ b/resources/js/test/lib/impersonation.test.tsx
@@ -1,0 +1,96 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const flushAll = vi.fn();
+const post = vi.fn();
+const del = vi.fn();
+const calls: string[] = [];
+
+vi.mock('@inertiajs/react', () => ({
+    router: {
+        flushAll: (...args: unknown[]) => {
+            calls.push('flushAll');
+
+            return flushAll(...args);
+        },
+        post: (...args: unknown[]) => {
+            calls.push('post');
+
+            return post(...args);
+        },
+        delete: (...args: unknown[]) => {
+            calls.push('delete');
+
+            return del(...args);
+        },
+        visit: vi.fn(),
+        patch: vi.fn(),
+    },
+}));
+
+import { ImpersonateBanner } from '@/components/impersonate-banner';
+import { useUserActions } from '@/hooks/users/use-user-actions';
+import { startImpersonation, stopImpersonation } from '@/lib/impersonation';
+import type { User } from '@/types/users';
+
+beforeEach(() => {
+    calls.length = 0;
+    vi.clearAllMocks();
+});
+
+/*
+ * O cache de prefetch do Inertia guarda respostas por URL e não sabe quem estava
+ * autenticado quando foram buscadas. Com 6 superfícies `<Link prefetch>` no
+ * painel e os controllers de impersonation devolvendo 302 (não
+ * `Inertia::location()`), o cache atravessa a troca de identidade inteiro — e
+ * um prefetch de /settings/profile feito pelo admin mostra o nome e o e-mail
+ * dele durante a personificação.
+ *
+ * Estes testes travam as duas metades da defesa: o módulo invalida, e ninguém
+ * fora dele fala com as rotas de impersonation.
+ */
+
+describe('lib/impersonation', () => {
+    it('invalidates the prefetch cache before starting impersonation', () => {
+        startImpersonation(7);
+
+        expect(flushAll).toHaveBeenCalledTimes(1);
+        expect(post).toHaveBeenCalledTimes(1);
+        expect(calls).toEqual(['flushAll', 'post']);
+    });
+
+    it('invalidates the prefetch cache before stopping impersonation', () => {
+        stopImpersonation();
+
+        expect(flushAll).toHaveBeenCalledTimes(1);
+        expect(del).toHaveBeenCalledTimes(1);
+        expect(calls).toEqual(['flushAll', 'delete']);
+    });
+
+    it('forwards visit options so callers keep their own onSuccess/onError', () => {
+        const onError = vi.fn();
+
+        startImpersonation(7, { onError });
+
+        expect(post).toHaveBeenCalledWith(expect.anything(), {}, { onError });
+    });
+});
+
+describe('call sites', () => {
+    it('flushes the cache when the banner stops impersonation', async () => {
+        render(<ImpersonateBanner active originalUserName="Ana" impersonatedUserName="Bruno" />);
+
+        await userEvent.click(screen.getByRole('link', { name: /clique aqui para sair/i }));
+
+        expect(calls).toEqual(['flushAll', 'delete']);
+    });
+
+    it('flushes the cache when the user list starts impersonation', () => {
+        const user = { id: 9 } as User;
+
+        renderHook(() => useUserActions({})).result.current.onImpersonate(user);
+
+        expect(calls).toEqual(['flushAll', 'post']);
+    });
+});


### PR DESCRIPTION
Closes #57

## O bug, e por que ele é invisível

O cache de prefetch do Inertia guarda respostas **por URL**, sem qualquer noção de quem estava autenticado quando foram buscadas. O painel tem os dois ingredientes:

- **6 superfícies `<Link prefetch>`** — `nav-main.tsx:58`, `app-sidebar.tsx:39`, `app-header.tsx:97`, `user-menu-content.tsx:25`, `settings/settings-sidebar.tsx:73`, `layouts/settings/layout.tsx:47`
- **3 pontos de troca de identidade sem invalidação** — `user-details-dialog.tsx`, `impersonate-banner.tsx`, `hooks/users/use-user-actions.ts`

`grep -rn "flushAll|flushByCacheTags|invalidateCacheTags|cacheTags" resources/js` antes desta fatia → **0 linhas**.

**O default do framework não cobre.** No core 3.6.1 instalado (`dist/index.js:2488-2490`), após uma visita bem-sucedida ele só faz `flushByCacheTags(invalidateCacheTags || [])` — que não remove nada, porque `tags.includes(tag)` é sempre falso em array vazio — mais `router.flush(page.get().url)`, que limpa **apenas a URL de destino**.

**O cheque que fecha o diagnóstico:** `StartImpersonateController.php:21` e `StopImpersonateController.php:19` devolvem `RedirectResponse` puro (302), **não** `Inertia::location()`. Fosse `location()`, a navegação dura limparia o cache sozinha e não haveria bug. Como é 302, a SPA não reinicia e o cache atravessa a troca inteiro.

**Efeito:** um prefetch de `/settings/profile` gerado com o admin logado continua no cache e é servido no clique seguinte — mostrando nome e e-mail do **admin** enquanto se personifica outra pessoa.

## Por que um módulo, e não três `flushAll()`

Os três call sites nasceram um de cada vez, sem saber uns dos outros — foi exatamente assim que o buraco apareceu. Espalhar `router.flushAll()` por eles conserta hoje e reabre no quarto.

`resources/js/lib/impersonation.ts` passa a ser o único caminho, e um teste de propriedade impede que as rotas `users.impersonate` sejam nomeadas fora dele. A quarta tela que precisar trocar de identidade herda o flush de graça.

## Por que `flushAll()` e não `cacheTags`

A forma idiomática na v3 seria taguear os `<Link>` com `cacheTags` e passar `invalidateCacheTags` nas visitas. Rejeitado por **modo de falha**:

| Abordagem | Como falha |
| --------- | ---------- |
| `cacheTags` / `invalidateCacheTags` | **Falha ABERTO** — esquecer a tag em 1 dos 6 `<Link>`, ou no 7º que alguém acrescentar, devolve dado de outra identidade em silêncio, sem sinal |
| `flushAll()` | **Falha FECHADO** — pior caso: refaz alguns prefetches, num momento raro |

Trocar de identidade invalida semanticamente **toda** página cacheada, então jogar tudo fora é a operação certa, não um exagero. Tags ficam reservadas para invalidação de escopo estreito.

## Verificação por mutação

| Mutação | Resultado |
| ------- | --------- |
| Tirar `router.flushAll()` de `startImpersonation` | ⨯ 3 testes falham |
| Somar um 4º call site chamando `router.post(route('users.impersonate'))` direto | ⨯ a guarda de propriedade de rota falha |
| Reverter `impersonate-banner` para o `router.delete` direto | ⨯ 2 testes falham |

13 testes no diretório, todos verdes no baseline.

## Nota de ordenação (fact-check que corrigiu o candidato original)

A análise inicial dizia que o flush **precisava** vir antes do `router.post`, senão o redirect resolveria do cache. Isso é **falso**: o cache só é consultado em `sendRequest()` (`dist:3186`), alcançado quando uma nova visita é iniciada por `router.visit`/`<Link>`; o 302 é seguido pelo axios na camada HTTP e nunca reentra ali. A página velha aparecia **no clique seguinte**, não no redirect. O flush vem antes por simplicidade — sem composição de callbacks —, não por corrida.

## Gates

- `composer ci:check` → exit 0 (307 testes)
- `corepack pnpm ci:check` → exit 0

Ambos rodaram também no `pre-push`.