### PR TITLE
[59]: fix(busca): mostra o spinner enquanto se digita e destrava o que não parava

### DIFF
--- a/resources/js/components/data-table/search-bar.tsx
+++ b/resources/js/components/data-table/search-bar.tsx
@@ -53,8 +53,19 @@ export function SearchBar({
                 onKeyDown={handleKeyDown}
                 aria-label={ariaLabel}
             />
+            {/*
+             * O indicador de busca ocupa o lugar da lupa, não o canto direito.
+             * Ali vive o botão de limpar, que aparece com o campo preenchido —
+             * exatamente quando a busca está em curso. Disputar aquele canto
+             * faria o X piscar a cada tecla, o que é pior do que não ter
+             * indicador. Aqui o slot já é fixo e o conteúdo só alterna.
+             */}
             <div className="absolute top-1/2 left-3 -translate-y-1/2 cursor-pointer" onClick={focusInput} role="button" aria-label="Focar busca">
-                <Search className="text-muted-foreground dark:text-muted-foreground/70 h-4 w-4" />
+                {isSearching ? (
+                    <div className="border-primary h-4 w-4 animate-spin rounded-full border-2 border-t-transparent" data-testid="search-spinner" />
+                ) : (
+                    <Search className="text-muted-foreground dark:text-muted-foreground/70 h-4 w-4" />
+                )}
             </div>
             {value && (
                 <button
@@ -69,11 +80,6 @@ export function SearchBar({
                 >
                     <X className="text-muted-foreground hover:text-foreground dark:text-muted-foreground/70 dark:hover:text-foreground/90 h-4 w-4 transition-colors duration-200" />
                 </button>
-            )}
-            {isSearching && !value && (
-                <div className="absolute top-1/2 right-3 -translate-y-1/2">
-                    <div className="border-primary h-4 w-4 animate-spin rounded-full border-2 border-t-transparent" />
-                </div>
             )}
         </div>
     );

--- a/resources/js/hooks/users/use-user-filters.ts
+++ b/resources/js/hooks/users/use-user-filters.ts
@@ -49,8 +49,17 @@ export function useUserFilters({ initialFilters = {}, routeName, debounceMs = SE
 
     // Debounced search effect - só dispara quando usuário digita
     useEffect(() => {
-        // Pula mount inicial e se busca já corresponde ao filtro atual
-        if (isInitialMount.current || localSearch === (initialFilters.search || '')) {
+        if (isInitialMount.current) {
+            return;
+        }
+
+        // O texto voltou ao que já está aplicado — nada a buscar. O cleanup do
+        // ciclo anterior já cancelou o timeout, então o `onFinish` que
+        // desligaria isSearching nunca vai acontecer: sem este reset, o estado
+        // fica preso em true (e a barra passa a exibir um spinner que não para).
+        if (localSearch === (initialFilters.search || '')) {
+            setIsSearching(false);
+
             return;
         }
 

--- a/resources/js/test/components/data-table/search-bar.test.tsx
+++ b/resources/js/test/components/data-table/search-bar.test.tsx
@@ -1,0 +1,46 @@
+import { SearchBar } from '@/components/data-table/search-bar';
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+function renderBar(props: Partial<ComponentProps<typeof SearchBar>> = {}) {
+    return render(<SearchBar value="" onChange={vi.fn()} onClear={vi.fn()} {...props} />);
+}
+
+/*
+ * O spinner vivia atrás de `isSearching && !value`, ou seja, só com o campo
+ * vazio — nunca enquanto se digita, que é quando ele serviria. Estes testes
+ * travam as duas metades: ele aparece durante a busca com texto, e não disputa
+ * o canto direito com o botão de limpar.
+ */
+describe('SearchBar', () => {
+    it('shows the spinner while searching with typed text', () => {
+        renderBar({ value: 'ana', isSearching: true });
+
+        expect(screen.getByTestId('search-spinner')).toBeInTheDocument();
+    });
+
+    it('shows the spinner while searching with an empty field', () => {
+        renderBar({ value: '', isSearching: true });
+
+        expect(screen.getByTestId('search-spinner')).toBeInTheDocument();
+    });
+
+    it('hides the spinner when no search is in flight', () => {
+        renderBar({ value: 'ana', isSearching: false });
+
+        expect(screen.queryByTestId('search-spinner')).not.toBeInTheDocument();
+    });
+
+    it('keeps the clear button available while searching', () => {
+        renderBar({ value: 'ana', isSearching: true });
+
+        expect(screen.getByRole('button', { name: 'Limpar busca' })).toBeInTheDocument();
+    });
+
+    it('does not offer a clear button when there is nothing to clear', () => {
+        renderBar({ value: '', isSearching: true });
+
+        expect(screen.queryByRole('button', { name: 'Limpar busca' })).not.toBeInTheDocument();
+    });
+});

--- a/resources/js/test/hooks/use-user-filters.test.ts
+++ b/resources/js/test/hooks/use-user-filters.test.ts
@@ -1,0 +1,63 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@inertiajs/react', () => ({
+    router: { get: vi.fn() },
+}));
+
+import { useUserFilters } from '@/hooks/users/use-user-filters';
+
+beforeEach(() => {
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+});
+
+/*
+ * O efeito de debounce liga `isSearching` antes de agendar o timeout, e o
+ * cleanup cancela esse timeout a cada tecla. Quando o texto volta ao valor que
+ * já está no filtro, o efeito sai pela guarda inicial — e o `onFinish` que
+ * desligaria o estado nunca acontece, porque request nenhum foi disparado.
+ *
+ * O estado fica preso em `true` com o campo vazio, que é justamente a condição
+ * em que a barra de busca decide mostrar o spinner. O único spinner que o
+ * usuário chegava a ver era um que não parava mais.
+ */
+describe('useUserFilters', () => {
+    it('turns the searching state on while the typed text has not settled', () => {
+        const { result } = renderHook(() => useUserFilters({ initialFilters: { search: '' }, routeName: 'users.index' }));
+
+        act(() => {
+            result.current.setLocalSearch('ana');
+        });
+
+        expect(result.current.isSearching).toBe(true);
+    });
+
+    it('turns the searching state off when the text returns to the applied filter', () => {
+        const { result } = renderHook(() => useUserFilters({ initialFilters: { search: '' }, routeName: 'users.index' }));
+
+        act(() => {
+            result.current.setLocalSearch('ana');
+        });
+
+        expect(result.current.isSearching).toBe(true);
+
+        // Apaga antes de o debounce vencer: o timeout é cancelado e nenhum
+        // request chega a sair, então não há onFinish para desligar o estado.
+        act(() => {
+            result.current.setLocalSearch('');
+        });
+
+        expect(result.current.isSearching).toBe(false);
+    });
+
+    it('keeps the searching state off on the initial mount', () => {
+        const { result } = renderHook(() => useUserFilters({ initialFilters: { search: 'ana' }, routeName: 'users.index' }));
+
+        expect(result.current.isSearching).toBe(false);
+    });
+});


### PR DESCRIPTION
Closes #59

`harvest: ctfinance resources/js/components/data-table/search-bar.tsx@b8c6d57` — o mesmo primitivo, com o mesmo defeito. A leitura comparada revelou o que já era nosso.

## Dois defeitos que se escondiam um atrás do outro

**A — o spinner nunca aparecia quando serviria.** `search-bar.tsx:73` renderizava sob `isSearching && !value`: só com o campo **vazio**, nunca durante a digitação. O estado era produzido e propagado corretamente (`use-user-filters.ts:31,154`) e descartado só na renderização.

**B — e quando aparecia, era porque tinha travado.** Em `use-user-filters.ts` o efeito de debounce liga `isSearching` **antes** de agendar o timeout, e o cleanup cancela esse timeout a cada tecla:

1. Usuário digita `a` → `setIsSearching(true)`, timeout agendado
2. Antes do debounce vencer, apaga → o cleanup cancela o timeout
3. O efeito re-roda com `localSearch === (initialFilters.search || '')` → early-return **sem desligar o estado**
4. O `onFinish` que o desligaria nunca acontece: o request nunca saiu

Estado preso em `true` com campo vazio — as duas condições do defeito A. O único spinner que o usuário via era um que **não parava mais**.

`use-user-search.ts`, o hook irmão, **não** tem o defeito B: usa `useDebouncedValue`, o request já está em voo quando o estado muda, e o `onFinish` sempre reseta.

## Por que o indicador foi para a esquerda

A análise original pedia um slot de largura fixa no canto direito alternando spinner e X. Medindo o efeito, isso é pior: o X aparece com o campo preenchido — exatamente quando a busca está em curso —, então ele **piscaria a cada tecla**. O canto esquerdo já é um slot fixo (a lupa), o glifo só alterna, e o botão de limpar fica estável. Zero disputa de espaço, zero piscar.

A região `aria-live` de `pages/users/index.tsx:139-141` já anunciava o estado a leitores de tela e continua intacta — a lacuna sempre foi estritamente visual.

## Verificação por mutação

O teste do hook foi escrito **antes** da correção e falhava reproduzindo o spinner travado (`expected true to be false`).

| Mutação | Resultado |
| ------- | --------- |
| Reverter o reset de `isSearching` no early-return | ⨯ `turns the searching state off when the text returns to the applied filter` |
| Voltar à condição antiga `isSearching && !value` | ⨯ `shows the spinner while searching with typed text` |
| Fazer o X sumir durante a busca (o piscar evitado) | ⨯ `keeps the clear button available while searching` |

## Alcance

1 tela hoje (`pages/users/index.tsx:168`), mas é o primitivo compartilhado que os derivados copiam — no ctfinance ele já se multiplicou por 9 telas com o mesmo defeito.

## Gates

- `composer ci:check` → exit 0 (311 testes)
- `corepack pnpm ci:check` → exit 0 (166 testes, +8)