### PR TITLE
[61]: fix(tema): pinta o fundo escuro com literal e declara o color-scheme

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -4,6 +4,9 @@
     <meta charset="utf-8" >
     <meta name="viewport" content="width=device-width, initial-scale=1" >
 
+    {{-- Faz o canvas, as barras de rolagem e os controles nativos seguirem o tema --}}
+    <meta name="color-scheme" content="{{ ($appearance ?? 'system') === 'system' ? 'light dark' : ($appearance ?? 'system') }}" >
+
     {{-- Inline script to detect system dark mode preference and apply it immediately --}}
     <script >
         (function() {
@@ -20,6 +23,14 @@
     </script >
 
     {{-- Inline style to set the HTML background color --}}
+    {{--
+        Os dois valores são literais de propósito. Este bloco existe para pintar
+        o fundo ANTES de o app.css chegar (ele vem pelo @vite lá embaixo), então
+        referenciar um token declarado no app.css o deixa inválido exatamente na
+        janela em que ele deveria valer. O hex escuro espelha
+        `--color-primary-dark` de resources/css/app.css, e um teste trava a
+        sincronia entre os dois.
+    --}}
     <style >
         html {
             background-color: white;
@@ -27,7 +38,7 @@
         }
 
         html.dark {
-            background-color: var(--color-primary-dark);
+            background-color: #0f2a44;
             transition: background-color 0.2s ease;
         }
     </style >

--- a/tests/Unit/Theme/InlineThemeBackgroundTest.php
+++ b/tests/Unit/Theme/InlineThemeBackgroundTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types = 1);
+
+/*
+|--------------------------------------------------------------------------
+| Fundo do tema antes do CSS chegar
+|--------------------------------------------------------------------------
+|
+| O `<style>` inline de resources/views/app.blade.php existe para pintar o
+| fundo antes de o app.css ser baixado — ele fica no topo do <head>, e o CSS
+| só entra pelo @vite mais abaixo. Isso o obriga a usar valores literais: um
+| `var(--token)` declarado no app.css é inválido em computed-value time
+| justamente na janela que o bloco existe para cobrir, e o fundo fica sem cor.
+|
+| Foi o que aconteceu em c2ffbc7 (um commit de fontes): a linha escura virou
+| `var(--color-primary-dark)` e ninguém viu, porque em produção o CSS é
+| render-blocking e o token já existe no primeiro paint. A janela real é o
+| `composer dev`, onde o Vite injeta o CSS por JS.
+|
+| O preço do literal é duplicação, e é isso que esta guarda cobra: o hex do
+| blade tem de continuar igual ao token do app.css.
+|
+*/
+
+function inlineThemeStyleBlock(): string
+{
+    $blade = (string) file_get_contents(dirname(__DIR__, 3) . '/resources/views/app.blade.php');
+
+    preg_match('/<style\s*>(.*?)<\/style\s*>/s', $blade, $matches);
+
+    return $matches[1] ?? '';
+}
+
+function appCssToken(string $token): string
+{
+    $css = (string) file_get_contents(dirname(__DIR__, 3) . '/resources/css/app.css');
+
+    preg_match('/--' . preg_quote($token, '/') . ':\s*([^;]+);/', $css, $matches);
+
+    return trim($matches[1] ?? '');
+}
+
+it('reads both files', function(): void {
+    expect(inlineThemeStyleBlock())->not->toBe('')
+        ->and(appCssToken('color-primary-dark'))->not->toBe('');
+});
+
+it('paints the dark background with a literal, never a css variable', function(): void {
+    expect(str_contains(inlineThemeStyleBlock(), 'var(--'))->toBe(
+        false,
+        'O <style> inline roda antes do app.css: um var() aqui fica sem valor '
+        . 'exatamente na janela que este bloco existe para cobrir. Use o literal '
+        . 'e deixe o teste de sincronia cobrar a igualdade com o token.'
+    );
+});
+
+it('keeps the inline dark background in sync with the app.css token', function(): void {
+    $token = appCssToken('color-primary-dark');
+
+    expect(str_contains(inlineThemeStyleBlock(), $token))->toBe(true, sprintf(
+        'O fundo escuro inline de resources/views/app.blade.php saiu de sincronia '
+        . 'com --color-primary-dark (%s) de resources/css/app.css. Os dois pintam '
+        . 'a mesma superfície em momentos diferentes do carregamento: divergir faz '
+        . 'a cor trocar sozinha quando o CSS termina de chegar.',
+        $token
+    ));
+});
+
+it('declares a color-scheme meta so native chrome follows the theme', function(): void {
+    $blade = (string) file_get_contents(dirname(__DIR__, 3) . '/resources/views/app.blade.php');
+
+    expect($blade)->toContain('name="color-scheme"');
+});


### PR DESCRIPTION
Closes #61

`harvest: ctfinance resources/views/app.blade.php@b8c6d57`

## A regressão

`resources/views/app.blade.php:30` pintava o fundo escuro com `var(--color-primary-dark)`. Esse token é declarado em `resources/css/app.css:107` — arquivo que chega pelo `@vite`, **abaixo** do `<style>` inline.

O bloco inline existe **justamente para funcionar sem o `app.css`**. Referenciar um token dele o torna inválido em computed-value time exatamente na janela que ele deveria cobrir.

`git blame`: a linha era `oklch(0.14 0.006 220)` literal até **`c2ffbc7`** ("feat: add Aptos, Montserrat, and Merriweather Sans font files…"). A linha irmã (`html { background-color: white; }`) continua literal — a inconsistência mostra que foi acidente num commit de fontes, não decisão.

## Severidade medida, não presumida

**Em produção não há flash.** Confirmado no manifest do build:

```
resources/js/app.tsx -> css: ['assets/app-Y1cdkAkY.css']
```

Ou seja, o `@vite` emite `<link rel="stylesheet">` render-blocking e o token já existe quando o primeiro paint acontece. O `var()` quebrado era **latente**.

A janela real está em **`composer dev`**, onde o Vite injeta o CSS por JS: até o bundle rodar, `html.dark` fica sem `background-color` e o canvas aparece branco.

**O ganho em produção vem da outra metade da fatia:** a meta `color-scheme`, que não existia no app (`grep` só achava em `errors/500.blade.php:9`). É ela que faz o canvas, as barras de rolagem e os controles nativos do navegador seguirem o tema — a página de erro já cuidava disso e o app não.

## O preço do literal

Duplicação: o hex vive no blade e o token no `app.css`. O teste cobra a sincronia — os dois pintam a mesma superfície em momentos diferentes do carregamento, e divergir faria a cor trocar sozinha quando o CSS termina de chegar.

## Verificação por mutação

| Mutação | Resultado |
| ------- | --------- |
| Repetir a regressão do `c2ffbc7` (hex → `var(--color-primary-dark)`) | ⨯ 2 testes falham |
| Mudar `--color-primary-dark` só no `app.css` | ⨯ o teste de sincronia falha, nomeando o novo valor |
| Remover a meta `color-scheme` | ⨯ o teste dela falha |

## Fora de escopo, com motivo

- **`data-theme` do ctfinance não entra:** é código morto lá — escrito em três lugares, e `grep -rn "data-theme" ctfinance/resources` não acha nenhum seletor que o consuma. O boilerplate usa `[data-radix-theme]` (`app.css:95`), que é outra coisa.
- **Trocar `classList.add` por `toggle` no script inline não é bug fix:** a classe `dark` só chega por `@class([...])` em `app.blade.php:2`, e nesse ramo o guard `appearance === 'system'` é falso — o script nunca roda sobre um `<html>` que já tem a classe. O runtime já usa a forma idempotente (`use-appearance.tsx:25`). Seria legibilidade, e não pode ser vendido como correção.

## Gates

- `composer ci:check` → exit 0 (315 testes, +4)
- `corepack pnpm ci:check` → exit 0 (158 testes)