### PR TITLE
[65]: fix(users): normaliza ordenação e page size vindos da URL

### DIFF
--- a/.ai/rules/controllers.md
+++ b/.ai/rules/controllers.md
@@ -22,3 +22,6 @@ Após mutações, redirecione com uma das quatro flash keys `success|error|warni
 
 ## Validação de escrita de domínio sempre via Form Request
 Toda validação de escrita em controllers de domínio usa Form Request — nunca $request->validate() inline. O Form Request carrega rules(), authorize() com $this->user()->can(Permissions::X) espelhando o can: da rota, e messages() em pt-BR. O scaffold herdado de Auth/Settings é a única exceção.
+
+## Ordenação e page size de URL são entrada não confiável
+Em listagem, `sort_by`, `sort_order` e `per_page` chegam do cliente e não podem ir crus para o builder: direção fora de `asc`/`desc` faz `Query\Builder::orderBy()` lançar `InvalidArgumentException` (500 alcançável por link) e page size sem teto puxa a tabela inteira num request. Normalize os três com `App\Support\Listing\ListQueryNormalizer` (`sortField` com allow-list explícita, `direction`, `perPage`) antes de tocar o query builder — allow-list só do campo não basta, a direção também precisa. E o eco em `filters` publica o valor NORMALIZADO, nunca o cru: com `withQueryString()` o valor volta para a URL, e ecoar o lixo torna o erro compartilhável por link.

--- a/app/Http/Controllers/User/IndexController.php
+++ b/app/Http/Controllers/User/IndexController.php
@@ -9,6 +9,7 @@ use App\Http\Resources\RoleResource;
 use App\Http\Resources\UserResource;
 use App\Models\User;
 use App\Services\RoleFilterService;
+use App\Support\Listing\ListQueryNormalizer;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -60,20 +61,17 @@ final class IndexController extends Controller
             }
         }
 
-        // Ordenação
-        $sortBy    = $request->get('sort_by', 'created_at');
-        $sortOrder = $request->get('sort_order', 'desc');
-
+        // Ordenação — campo E direção vêm da URL, então os dois são normalizados
+        // antes de tocar o builder (direção fora de asc/desc faz orderBy lançar).
         $allowedSortFields = ['name', 'email', 'created_at', 'updated_at'];
 
-        if (in_array($sortBy, $allowedSortFields)) {
-            $query->orderBy($sortBy, $sortOrder);
-        } else {
-            $query->orderBy('created_at', 'desc');
-        }
+        $sortBy    = ListQueryNormalizer::sortField($request->get('sort_by'), $allowedSortFields, 'created_at');
+        $sortOrder = ListQueryNormalizer::direction($request->get('sort_order'));
 
-        // Paginação
-        $perPage = $request->get('per_page', 15);
+        $query->orderBy($sortBy, $sortOrder);
+
+        // Paginação — com piso e teto, senão ?per_page=999999 puxa a tabela inteira
+        $perPage = ListQueryNormalizer::perPage($request->get('per_page'));
         $users   = $query->paginate($perPage)->withQueryString();
 
         // Para o filtro, usa roles visíveis baseado no usuário atual da sessão

--- a/app/Support/Listing/ListQueryNormalizer.php
+++ b/app/Support/Listing/ListQueryNormalizer.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Support\Listing;
+
+/**
+ * Normaliza ordenação e page size vindos da querystring de uma listagem.
+ *
+ * Estes três parâmetros são entrada NÃO CONFIÁVEL, mesmo em rota autenticada:
+ *
+ * - direção fora de `asc`/`desc` faz `Query\Builder::orderBy()` lançar
+ *   `InvalidArgumentException`, ou seja, 500 alcançável por link;
+ * - campo de ordenação cru vira nome de coluna no SQL;
+ * - page size sem teto puxa a tabela inteira num request.
+ *
+ * Métodos estáticos puros, sem Eloquent — o controller segue chamando o
+ * builder direto, como manda a convenção de `.ai/rules/controllers.md`.
+ */
+final class ListQueryNormalizer
+{
+    public const int PER_PAGE_MIN = 5;
+
+    public const int PER_PAGE_MAX = 50;
+
+    public const int PER_PAGE_DEFAULT = 15;
+
+    /**
+     * Devolve `$value` apenas se ele for exatamente um dos campos permitidos.
+     *
+     * A comparação é estrita e sensível a caixa de propósito: o retorno vira
+     * nome de coluna, então "quase igual" não serve.
+     *
+     * @param  list<string>  $allowed
+     */
+    public static function sortField(mixed $value, array $allowed, string $default): string
+    {
+        return is_string($value) && in_array($value, $allowed, true)
+            ? $value
+            : $default;
+    }
+
+    /**
+     * Devolve `asc` ou `desc` — nunca outra coisa.
+     *
+     * `$default` também passa pela normalização, para que um default errado
+     * no call site não reintroduza o mesmo 500 que este método existe para
+     * evitar.
+     */
+    public static function direction(mixed $value, string $default = 'desc'): string
+    {
+        foreach ([$value, $default] as $candidate) {
+            if (!is_string($candidate)) {
+                continue;
+            }
+
+            $normalized = strtolower(trim($candidate));
+
+            if ($normalized === 'asc' || $normalized === 'desc') {
+                return $normalized;
+            }
+        }
+
+        return 'desc';
+    }
+
+    /**
+     * Devolve um page size dentro de [PER_PAGE_MIN, PER_PAGE_MAX].
+     *
+     * Entrada não numérica (texto, array, null) cai no default em vez de
+     * virar 0 por cast silencioso — `paginate(0)` traz a tabela inteira.
+     */
+    public static function perPage(mixed $value, int $default = self::PER_PAGE_DEFAULT): int
+    {
+        $perPage = is_numeric($value) ? (int) $value : $default;
+
+        return max(self::PER_PAGE_MIN, min(self::PER_PAGE_MAX, $perPage));
+    }
+}

--- a/tests/Feature/User/IndexControllerTest.php
+++ b/tests/Feature/User/IndexControllerTest.php
@@ -44,3 +44,78 @@ it('forbids a user without manage_users', function(): void {
 it('redirects guests to the login page', function(): void {
     $this->get(route('users.index'))->assertRedirect(route('login'));
 });
+
+/*
+|--------------------------------------------------------------------------
+| Ordenação e paginação vindas da URL
+|--------------------------------------------------------------------------
+|
+| Antes desta fatia a direção ia crua para orderBy() e `per_page` não tinha
+| teto: /users?sort_order=<lixo> devolvia 500 (Query\Builder lança para
+| direção fora de asc/desc) e ?per_page=999999 paginava a tabela inteira.
+| O eco em `filters` publica o valor NORMALIZADO — senão o lixo volta para a
+| URL pelo withQueryString() e o 500 se torna compartilhável por link.
+|
+*/
+
+it('sorts by an allowed field in the requested direction', function(): void {
+    actingAsSuperUser()->update(['name' => 'Mmm Meio']);
+    User::factory()->create(['name' => 'Aaa Primeira']);
+    User::factory()->create(['name' => 'Zzz Ultima']);
+
+    $this->get(route('users.index', ['sort_by' => 'name', 'sort_order' => 'asc']))
+        ->assertOk()
+        ->assertInertia(fn(Assert $page) => $page
+            ->where('users.0.name', 'Aaa Primeira')
+            ->where('filters.sort_by', 'name')
+            ->where('filters.sort_order', 'asc'));
+
+    $this->get(route('users.index', ['sort_by' => 'name', 'sort_order' => 'desc']))
+        ->assertOk()
+        ->assertInertia(fn(Assert $page) => $page->where('users.0.name', 'Zzz Ultima'));
+});
+
+it('normalizes the case of a valid sort direction', function(): void {
+    actingAsSuperUser();
+
+    $this->get(route('users.index', ['sort_by' => 'name', 'sort_order' => 'ASC']))
+        ->assertOk()
+        ->assertInertia(fn(Assert $page) => $page->where('filters.sort_order', 'asc'));
+});
+
+it('falls back to a safe sort direction instead of failing', function(mixed $sortOrder): void {
+    actingAsSuperUser();
+
+    $this->get(route('users.index', ['sort_by' => 'name', 'sort_order' => $sortOrder]))
+        ->assertOk()
+        ->assertInertia(fn(Assert $page) => $page->where('filters.sort_order', 'desc'));
+})->with([
+    'lixo'          => ['ordem-aleatoria'],
+    'fragmento sql' => ['asc, (select 1)'],
+    'array'         => [['asc']],
+    'vazio'         => [''],
+]);
+
+it('falls back to the default sort field when sort_by is not allowed', function(): void {
+    actingAsSuperUser();
+
+    $this->get(route('users.index', ['sort_by' => 'password', 'sort_order' => 'asc']))
+        ->assertOk()
+        ->assertInertia(fn(Assert $page) => $page
+            ->where('filters.sort_by', 'created_at')
+            ->where('filters.sort_order', 'asc'));
+});
+
+it('caps and floors per_page', function(mixed $perPage, int $expected): void {
+    actingAsSuperUser();
+
+    $this->get(route('users.index', ['per_page' => $perPage]))
+        ->assertOk()
+        ->assertInertia(fn(Assert $page) => $page->where('pagination.per_page', $expected));
+})->with([
+    'acima do teto'   => [999_999, 50],
+    'abaixo do piso'  => [0, 5],
+    'não numérico'    => ['muitos', 15],
+    'array'           => [[50], 15],
+    'dentro da faixa' => [25, 25],
+]);

--- a/tests/Unit/Support/Listing/ListQueryNormalizerTest.php
+++ b/tests/Unit/Support/Listing/ListQueryNormalizerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Support\Listing\ListQueryNormalizer;
+
+/*
+|--------------------------------------------------------------------------
+| Ordenação e paginação vindas da URL são entrada NÃO CONFIÁVEL.
+|--------------------------------------------------------------------------
+|
+| Direção fora de asc/desc faz Query\Builder::orderBy() lançar
+| InvalidArgumentException ("Order direction must be a SortDirection, ...") —
+| ou seja, 500 alcançável por querystring. Page size sem teto puxa a tabela
+| inteira num request. Estes testes travam o fallback dos dois.
+|
+*/
+
+describe('sortField', function(): void {
+    it('mantém um campo da allow-list', function(): void {
+        expect(ListQueryNormalizer::sortField('name', ['name', 'email'], 'created_at'))->toBe('name');
+    });
+
+    it('cai no default para campo fora da allow-list', function(): void {
+        expect(ListQueryNormalizer::sortField('senha', ['name', 'email'], 'created_at'))->toBe('created_at');
+    });
+
+    it('cai no default para tipo que não é string', function(mixed $value): void {
+        expect(ListQueryNormalizer::sortField($value, ['name'], 'created_at'))->toBe('created_at');
+    })->with([
+        'array' => [['name']],
+        'null'  => [null],
+        'int'   => [1],
+        'bool'  => [true],
+    ]);
+
+    it('não casa campo por variação de caixa', function(): void {
+        expect(ListQueryNormalizer::sortField('NAME', ['name'], 'created_at'))->toBe('created_at');
+    });
+});
+
+describe('direction', function(): void {
+    it('mantém as duas direções válidas', function(string $value): void {
+        expect(ListQueryNormalizer::direction($value))->toBe($value);
+    })->with(['asc', 'desc']);
+
+    it('normaliza a caixa e o espaço em volta', function(): void {
+        expect(ListQueryNormalizer::direction(' ASC '))->toBe('asc')
+            ->and(ListQueryNormalizer::direction('Desc'))->toBe('desc');
+    });
+
+    it('cai no default para qualquer coisa que não seja asc ou desc', function(mixed $value): void {
+        expect(ListQueryNormalizer::direction($value))->toBe('desc');
+    })->with([
+        'lixo'          => ['ordem-aleatoria'],
+        'fragmento sql' => ['asc, (select 1)'],
+        'vazio'         => [''],
+        'array'         => [['asc']],
+        'null'          => [null],
+        'int'           => [1],
+    ]);
+
+    it('respeita o default declarado quando a entrada é inválida', function(): void {
+        expect(ListQueryNormalizer::direction('lixo', 'asc'))->toBe('asc');
+    });
+
+    it('não deixa um default inválido reintroduzir a direção crua', function(): void {
+        expect(ListQueryNormalizer::direction('lixo', 'ordem-aleatoria'))->toBe('desc');
+    });
+});
+
+describe('perPage', function(): void {
+    it('mantém um valor dentro da faixa', function(): void {
+        expect(ListQueryNormalizer::perPage(25))->toBe(25);
+    });
+
+    it('aceita numérico em string, como vem da querystring', function(): void {
+        expect(ListQueryNormalizer::perPage('25'))->toBe(25);
+    });
+
+    it('aplica o teto', function(mixed $value): void {
+        expect(ListQueryNormalizer::perPage($value))->toBe(ListQueryNormalizer::PER_PAGE_MAX);
+    })->with([
+        'absurdo'   => [999_999],
+        'em string' => ['999999'],
+    ]);
+
+    it('aplica o piso', function(mixed $value): void {
+        expect(ListQueryNormalizer::perPage($value))->toBe(ListQueryNormalizer::PER_PAGE_MIN);
+    })->with([
+        'zero'     => [0],
+        'negativo' => [-10],
+    ]);
+
+    it('cai no default para entrada não numérica', function(mixed $value): void {
+        expect(ListQueryNormalizer::perPage($value))->toBe(15);
+    })->with([
+        'texto' => ['muitos'],
+        'array' => [[50]],
+        'null'  => [null],
+        'vazio' => [''],
+    ]);
+
+    it('respeita o default declarado', function(): void {
+        expect(ListQueryNormalizer::perPage('muitos', 20))->toBe(20);
+    });
+});


### PR DESCRIPTION
Fecha #65. Primeira fatia da **dimensão 5 (UX)** da harvest v2 — candidato E17.

`harvest: ctfinance app/Http/Controllers/RecurringExpense/IndexController.php@b8c6d57`

## O defeito

`app/Http/Controllers/User/IndexController.php` fazia allow-list só do **campo** de ordenação. A **direção** ia crua para `orderBy()`:

| URL | Antes | Depois |
| --- | ----- | ------ |
| `/users?sort_order=ordem-aleatoria` | **500** | 200, cai em `desc` |
| `/users?sort_order[]=asc` | **500** | 200, cai em `desc` |
| `/users?sort_order=` (vazio) | **500** | 200, cai em `desc` |
| `/users?sort_by=password` | 200 (já caía em `created_at`) | idem |
| `/users?per_page=999999` | tabela inteira num request | teto de 50 |
| `/users?per_page=0` | `paginate(0)` | piso de 5 |
| `/users?per_page=muitos` | `paginate("muitos")` | default 15 |

O 500 é `InvalidArgumentException: Order direction must be a SortDirection, "asc" or "desc"`, de `vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:2992` — reproduzido pelos testes antes da correção.

Rota autenticada e autorizada (`can:manage_users`), então não é exposição anônima. Mas o eco em `filters` publicava o valor **cru**, e com `withQueryString()` ele volta para a URL: o erro era compartilhável por link.

## A correção

Absorve a forma que o ctfinance já usa em `RecurringExpense/IndexController.php:94-103` (allow-list de campo **e** direção, teto de page size), extraída para `App\Support\Listing\ListQueryNormalizer` — `final`, métodos estáticos puros, no estilo de `Support/Br/PhoneNormalizer`, como manda `.ai/rules/support.md`.

**Por que em `Support` e não num query object ou FormRequest:** `.ai/rules/controllers.md` diz que não existe camada de query objects e que extração para `App\Services` é só para lógica reusada por vários controllers. O normalizador não toca Eloquent — normaliza escalares —, então cabe em `Support` sem abrir camada nova, e o próximo módulo de listagem reusa. Um FormRequest daria 422 num GET de listagem, o que quebraria bookmark antigo; a normalização graciosa é deliberada.

## Verificação por mutação

Além de passar verde:

| Mutação aplicada | Resultado |
| ---------------- | --------- |
| Direção crua no `orderBy()` (o defeito original) | ⨯ 5 testes falham |
| `perPage()` sem teto/piso | ⨯ 2 falham (teto e piso) |
| Allow-list de campo desligada | ⨯ 3 falham |
| `$default` de direção sem validação | ⨯ 1 falha |

A última mutação **passou verde na primeira rodada** — a proteção contra `$default` inválido estava sem cobertura. O teste que faltava entrou antes do commit.

## Gates

`composer ci:check` exit 0 — **352 testes / 1831 asserções** (+41 sobre a `main`, exatamente os novos).
`corepack pnpm ci:check` exit 0 (não toquei frontend; rodado pelo pre-push mesmo assim).

## Fica registrado

`sort_by`/`sort_order` **não são emitidos pela UI hoje** (`resources/js` só lê `per_page`, nunca envia). O E19 da harvest propõe ligar a ordenação clicável nos cabeçalhos — esta fatia é pré-requisito dele, senão o 500 vira alcançável por clique em vez de por URL montada à mão.