### PR TITLE
[69]: fix(theme): desfaz a colisão de token que matava o dark mode

### DIFF
--- a/.ai/rules/css.md
+++ b/.ai/rules/css.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - 'resources/css/**'
+---
+
+# Css
+
+## `--color-*` é namespace do `@theme`, não lugar para hex de marca
+O Tailwind gera utilitário de cor a partir de cada `--color-X` do bloco `@theme` (`bg-X`, `text-X`, `border-X`…). Declarar um `--color-*` em qualquer outro lugar do arquivo **sombreia o do `@theme` sem aviso**, porque declaração fora de layer vence declaração dentro de `@layer theme`: o utilitário passa a resolver para o valor cru e o `.dark { … }` nunca chega nele. Foi o que aconteceu por meses com `--color-primary` e `--color-accent` (`text-primary` no escuro dava 1.28:1 e o comentário "high-contrast in dark mode" descrevia efeito morto). Os hexes da marca vivem em `--brand-*`; o `@theme` só mapeia token semântico para `var(--token)`, nunca para literal. `resources/js/test/styles/theme-tokens.test.ts` trava isso.
+
+## Par de token que vira texto tem contraste medido, não estimado
+Todo par `--X` / `--X-foreground` precisa atingir 4.5:1 nos DOIS temas, e o teste de contrato calcula a razão resolvendo as cadeias de `var()` — não confie em olho nem em "parece escuro o bastante". Ao acrescentar um token semântico, acrescente a linha correspondente na tabela do teste no mesmo commit. Cuidado com o token que faz dois trabalhos: um `--X` usado como preenchimento (precisa contrastar com o próprio foreground) e como cor de texto sobre o canvas (precisa contrastar com o `--background`) puxa para lados opostos — nesse caso a saída é separar em tokens de estado, não escolher um meio-termo que reprova nos dois usos.
+
+## Folha de terceiro entra em layer
+`@import` de CSS de biblioteca traz declarações fora de layer, que vencem o `@theme`. Hoje `@radix-ui/themes/styles.css` redeclara `--color-background` e sequestra `bg-background` no app inteiro — dívida registrada, ainda não paga. Ao acrescentar folha de terceiro, importe em `layer(...)` com a ordem declarada, ou reafirme explicitamente os tokens que ela pisa.

--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -9,6 +9,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | app/Http/Controllers/** | .ai/rules/controllers.md |
 | app/Enum/** | .ai/rules/enum.md |
 | app/Events/** | .ai/rules/events.md |
+| resources/css/** | .ai/rules/css.md |
 | resources/js/** | .ai/rules/js.md |
 | app/Listeners/** | .ai/rules/listeners.md |
 | app/Http/Middleware/** | .ai/rules/middleware.md |

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -104,28 +104,27 @@
 /* -------------------------------------------------------------------------- */
 :root {
     /* Application color palette - base colors */
-    --color-primary-dark: #0f2a44;
-    --color-primary: #1f3c57;
-    --color-primary-darker: #2c485e;
-    --color-accent-light: #8ac7e5;
-    --color-accent: #379bcb;
-    --color-muted-light: #e6e7e8;
+    --brand-navy-dark: #0f2a44;
+    --brand-navy-soft: #2c485e;
+    --brand-cyan-light: #8ac7e5;
+    --brand-cyan: #379bcb;
+    --brand-gray: #e6e7e8;
 
     /* Map application colors to theme variables - LIGHT MODE */
     --background: white;
-    --foreground: var(--color-primary-dark);
+    --foreground: var(--brand-navy-dark);
     --card: white;
-    --card-foreground: var(--color-primary-dark);
+    --card-foreground: var(--brand-navy-dark);
     --popover: white;
-    --popover-foreground: var(--color-primary-dark);
-    --primary: var(--color-primary-dark);
+    --popover-foreground: var(--brand-navy-dark);
+    --primary: var(--brand-navy-dark);
     --primary-foreground: white;
-    --secondary: var(--color-accent-light);
-    --secondary-foreground: var(--color-primary-dark);
-    --muted: var(--color-muted-light);
-    --muted-foreground: var(--color-primary-darker);
-    --accent: var(--color-accent-light);
-    --accent-foreground: var(--color-primary-dark);
+    --secondary: var(--brand-cyan-light);
+    --secondary-foreground: var(--brand-navy-dark);
+    --muted: var(--brand-gray);
+    --muted-foreground: var(--brand-navy-soft);
+    --accent: var(--brand-cyan-light);
+    --accent-foreground: var(--brand-navy-dark);
     --destructive: #e11d48;
     --destructive-foreground: white;
     --success: #16a34a;
@@ -134,25 +133,25 @@
     --warning-foreground: white;
     --info: #0ea5e9;
     --info-foreground: white;
-    --border: var(--color-muted-light);
-    --input: var(--color-muted-light);
-    --ring: var(--color-accent-light);
-    --chart-1: var(--color-primary-dark);
-    --chart-2: var(--color-accent-light);
-    --chart-3: var(--color-primary-darker);
+    --border: var(--brand-gray);
+    --input: var(--brand-gray);
+    --ring: var(--brand-cyan-light);
+    --chart-1: var(--brand-navy-dark);
+    --chart-2: var(--brand-cyan-light);
+    --chart-3: var(--brand-navy-soft);
     --chart-4: #4b9cd3;
     --chart-5: #13b5ea;
     --radius: 0.625rem;
 
     /* Sidebar - LIGHT MODE */
     --sidebar: white;
-    --sidebar-foreground: var(--color-primary-dark);
-    --sidebar-primary: var(--color-primary-dark);
+    --sidebar-foreground: var(--brand-navy-dark);
+    --sidebar-primary: var(--brand-navy-dark);
     --sidebar-primary-foreground: white;
-    --sidebar-accent: var(--color-accent-light);
-    --sidebar-accent-foreground: var(--color-primary-dark);
-    --sidebar-border: var(--color-muted-light);
-    --sidebar-ring: var(--color-accent-light);
+    --sidebar-accent: var(--brand-cyan-light);
+    --sidebar-accent-foreground: var(--brand-navy-dark);
+    --sidebar-border: var(--brand-gray);
+    --sidebar-ring: var(--brand-cyan-light);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -160,47 +159,49 @@
 /* -------------------------------------------------------------------------- */
 .dark {
     /* Dark mode - improved for better contrast and consistency */
-    --background: var(--color-primary-dark);
+    --background: var(--brand-navy-dark);
     --foreground: #ffffff;
-    --card: var(--color-primary-dark);
+    --card: var(--brand-navy-dark);
     --card-foreground: #ffffff;
-    --popover: var(--color-primary-dark);
+    --popover: var(--brand-navy-dark);
     --popover-foreground: #ffffff;
-    /* Buttons/CTAs should be high-contrast in dark mode */
-    --primary: var(--color-accent);
-    --primary-foreground: #ffffff;
+    /* Buttons/CTAs should be high-contrast in dark mode.
+       O texto sobre o ciano e navy, nao branco: branco da 3.13:1 (reprova AA)
+       e o navy da 4.68:1. Medido, nao estimado — ver o teste de contraste. */
+    --primary: var(--brand-cyan);
+    --primary-foreground: var(--brand-navy-dark);
     --secondary: #2c485e;
     --secondary-foreground: #ffffff;
     --muted: #1a3a5a;
     --muted-foreground: #e6e7e8;
     --accent: #a5d8f3;
-    --accent-foreground: var(--color-primary-dark);
+    --accent-foreground: var(--brand-navy-dark);
     --destructive: #f43f5e;
     --destructive-foreground: #ffffff;
     --success: #22c55e;
     --success-foreground: #ffffff;
     --warning: #fbbf24;
-    --warning-foreground: var(--color-primary-dark);
+    --warning-foreground: var(--brand-navy-dark);
     --info: #38bdf8;
-    --info-foreground: var(--color-primary-dark);
-    --border: var(--color-primary-darker);
-    --input: var(--color-primary-darker);
-    --ring: var(--color-accent-light);
-    --chart-1: var(--color-accent-light);
+    --info-foreground: var(--brand-navy-dark);
+    --border: var(--brand-navy-soft);
+    --input: var(--brand-navy-soft);
+    --ring: var(--brand-cyan-light);
+    --chart-1: var(--brand-cyan-light);
     --chart-2: #4b9cd3;
     --chart-3: #13b5ea;
     --chart-4: #a5d8f3;
     --chart-5: #d6ebf7;
 
     /* Sidebar - DARK MODE */
-    --sidebar: var(--color-primary-dark);
+    --sidebar: var(--brand-navy-dark);
     --sidebar-foreground: #ffffff;
-    --sidebar-primary: var(--color-accent-light);
-    --sidebar-primary-foreground: var(--color-primary-dark);
-    --sidebar-accent: var(--color-primary-darker);
+    --sidebar-primary: var(--brand-cyan-light);
+    --sidebar-primary-foreground: var(--brand-navy-dark);
+    --sidebar-accent: var(--brand-navy-soft);
     --sidebar-accent-foreground: #ffffff;
     --sidebar-border: #1e3a4f;
-    --sidebar-ring: var(--color-accent-light);
+    --sidebar-ring: var(--brand-cyan-light);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/resources/js/test/styles/theme-tokens.test.ts
+++ b/resources/js/test/styles/theme-tokens.test.ts
@@ -1,0 +1,181 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Contrato do bloco `@theme` de `resources/css/app.css`.
+ *
+ * Existe por causa de um bug que viveu meses sem ninguém ver: `--color-primary`
+ * estava declarado DUAS vezes — uma dentro do `@theme` (`var(--primary)`) e
+ * outra num `:root` sem layer (`#1f3c57`). Declaração sem layer vence
+ * declaração em `@layer`, então `bg-primary`/`text-primary` resolviam para o
+ * mesmo hex nos DOIS temas e o `.dark { --primary }` nunca chegava a
+ * utilitário nenhum. `text-primary` no escuro dava 1.28:1.
+ *
+ * Duas guardas, e a segunda é a que teria pego a regressão que o CONSERTO
+ * quase introduziu: com a colisão desfeita, o `--primary` do escuro passou a
+ * valer de verdade e o par com `--primary-foreground` caiu para 3.13:1.
+ */
+
+const css = readFileSync(resolve(import.meta.dirname, '../../../css/app.css'), 'utf8');
+
+/** Recorta o corpo de um bloco de primeiro nível pelo seletor. */
+function block(selector: string): string {
+    const start = css.indexOf(`${selector} {`);
+
+    if (start === -1) {
+        throw new Error(`Bloco "${selector}" não encontrado em app.css`);
+    }
+
+    const open = css.indexOf('{', start);
+    let depth = 0;
+
+    for (let i = open; i < css.length; i++) {
+        if (css[i] === '{') depth++;
+        if (css[i] === '}') {
+            depth--;
+
+            if (depth === 0) return css.slice(open + 1, i);
+        }
+    }
+
+    throw new Error(`Bloco "${selector}" não fecha`);
+}
+
+/** Pares `--nome: valor` de um corpo de bloco, ignorando aninhados. */
+function declarations(body: string): Map<string, string> {
+    const out = new Map<string, string>();
+
+    for (const [, name, value] of body.matchAll(/(--[\w-]+)\s*:\s*([^;}]+);/g)) {
+        out.set(name, value.trim());
+    }
+
+    return out;
+}
+
+const themeBody = block('@theme');
+const rootVars = declarations(block(':root'));
+const darkVars = declarations(block('.dark'));
+
+/** Resolve cadeias de `var(--x)` até chegar num literal. */
+function resolveToken(name: string, scope: Map<string, string>): string {
+    const seen = new Set<string>();
+    let value = scope.get(name) ?? rootVars.get(name);
+
+    while (value !== undefined) {
+        const match = /^var\(\s*(--[\w-]+)\s*\)$/.exec(value);
+
+        if (!match) return value;
+
+        const next = match[1];
+
+        if (seen.has(next)) throw new Error(`Ciclo de var() em ${name}`);
+
+        seen.add(next);
+        value = scope.get(next) ?? rootVars.get(next);
+    }
+
+    throw new Error(`Token ${name} não resolve para literal`);
+}
+
+function relativeLuminance(hex: string): number {
+    const normalized = hex.trim().toLowerCase() === 'white' ? '#ffffff' : hex.trim();
+    const raw = normalized.replace('#', '');
+    const full = raw.length === 3 ? [...raw].map((c) => c + c).join('') : raw;
+
+    const channels = [0, 2, 4].map((i) => {
+        const channel = parseInt(full.slice(i, i + 2), 16) / 255;
+
+        return channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+    });
+
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrast(a: string, b: string): number {
+    const [x, y] = [relativeLuminance(a), relativeLuminance(b)];
+
+    return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
+}
+
+describe('namespace do @theme', () => {
+    it('não declara nenhum --color-* fora do bloco @theme', () => {
+        // Esta é a guarda do bug original. `--color-*` é o namespace que o
+        // Tailwind usa para gerar utilitário de cor; declarar um deles em
+        // qualquer outro lugar do arquivo sombreia o do @theme sem aviso.
+        const foraDoTheme = css.replace(themeBody, '');
+        const infratores = [...foraDoTheme.matchAll(/^\s*(--color-[\w-]+)\s*:/gm)].map((m) => m[1]);
+
+        expect(infratores).toEqual([]);
+    });
+
+    it('mantém a paleta base fora do namespace de utilitário', () => {
+        // Os hexes da marca vivem em --brand-*, justamente para não colidirem.
+        expect([...rootVars.keys()].filter((k) => k.startsWith('--brand-'))).not.toHaveLength(0);
+    });
+
+    it('exporta pelos utilitários apenas tokens semânticos', () => {
+        const semLiteral = [...declarations(themeBody).entries()]
+            .filter(([name]) => name.startsWith('--color-'))
+            .filter(([, value]) => !value.startsWith('var('));
+
+        expect(semLiteral).toEqual([]);
+    });
+});
+
+describe('contraste dos pares que viram texto', () => {
+    // A tabela é o contrato. Um par novo entra aqui junto com o token.
+    const pares: Array<[string, string, string]> = [
+        ['primary', '--primary-foreground', '--primary'],
+        ['secondary', '--secondary-foreground', '--secondary'],
+        ['accent', '--accent-foreground', '--accent'],
+        ['muted', '--muted-foreground', '--muted'],
+        ['card', '--card-foreground', '--card'],
+        ['background/foreground', '--foreground', '--background'],
+    ];
+
+    describe.each([
+        ['claro', new Map<string, string>()],
+        ['escuro', darkVars],
+    ])('tema %s', (_tema, scope) => {
+        it.each(pares)('%s atinge AA (4.5:1)', (_nome, fg, bg) => {
+            const ratio = contrast(resolveToken(fg, scope), resolveToken(bg, scope));
+
+            expect(ratio).toBeGreaterThanOrEqual(4.5);
+        });
+    });
+
+    /**
+     * `destructive` no escuro está em 3.67:1 e NÃO passa. É dívida conhecida,
+     * anterior a esta fatia, e não dá para pagar aqui: o mesmo token serve de
+     * preenchimento (precisa ser escuro o bastante para texto branco) e de cor
+     * de texto sobre o canvas escuro (precisa ser claro o bastante). Medido:
+     * escurecer para #e11d48 leva o botão a 4.70 mas derruba `text-destructive`
+     * de 3.99 para 3.12 — e é justamente `text-destructive` que a fatia E6 vai
+     * passar a usar no `InputError`.
+     *
+     * A cura é separar preenchimento de texto (candidato F3, tokens
+     * `--state-*`). Até lá isto fica como CATRACA: não conserta, mas impede
+     * piorar, e a fatia F3 sobe o piso ao passar por aqui.
+     */
+    const DIVIDA_DESTRUCTIVE_ESCURO = 3.67;
+
+    it('destructive no escuro não piora enquanto o F3 não separa fill de texto', () => {
+        const ratio = contrast(resolveToken('--destructive-foreground', darkVars), resolveToken('--destructive', darkVars));
+
+        expect(ratio).toBeGreaterThanOrEqual(DIVIDA_DESTRUCTIVE_ESCURO);
+        expect(ratio, 'se passou de 4.5, o F3 chegou — mova o par para a tabela de cima').toBeLessThan(4.5);
+    });
+
+    it('destructive no tema claro passa', () => {
+        const ratio = contrast(resolveToken('--destructive-foreground', new Map()), resolveToken('--destructive', new Map()));
+
+        expect(ratio).toBeGreaterThanOrEqual(4.5);
+    });
+
+    it('o --primary do escuro é de fato diferente do claro', () => {
+        // Se a colisão voltar, os dois viram o mesmo hex e este teste cai —
+        // é o sintoma observável do bug, medido no valor e não no arquivo.
+        expect(resolveToken('--primary', darkVars)).not.toBe(resolveToken('--primary', new Map()));
+    });
+});

--- a/tests/Unit/Theme/InlineThemeBackgroundTest.php
+++ b/tests/Unit/Theme/InlineThemeBackgroundTest.php
@@ -14,7 +14,7 @@ declare(strict_types = 1);
 | justamente na janela que o bloco existe para cobrir, e o fundo fica sem cor.
 |
 | Foi o que aconteceu em c2ffbc7 (um commit de fontes): a linha escura virou
-| `var(--color-primary-dark)` e ninguém viu, porque em produção o CSS é
+| `var(--color-primary-dark)` — hoje `--brand-navy-dark` — e ninguém viu, porque em produção o CSS é
 | render-blocking e o token já existe no primeiro paint. A janela real é o
 | `composer dev`, onde o Vite injeta o CSS por JS.
 |
@@ -43,7 +43,7 @@ function appCssToken(string $token): string
 
 it('reads both files', function(): void {
     expect(inlineThemeStyleBlock())->not->toBe('')
-        ->and(appCssToken('color-primary-dark'))->not->toBe('');
+        ->and(appCssToken('brand-navy-dark'))->not->toBe('');
 });
 
 it('paints the dark background with a literal, never a css variable', function(): void {
@@ -56,11 +56,11 @@ it('paints the dark background with a literal, never a css variable', function()
 });
 
 it('keeps the inline dark background in sync with the app.css token', function(): void {
-    $token = appCssToken('color-primary-dark');
+    $token = appCssToken('brand-navy-dark');
 
     expect(str_contains(inlineThemeStyleBlock(), $token))->toBe(true, sprintf(
         'O fundo escuro inline de resources/views/app.blade.php saiu de sincronia '
-        . 'com --color-primary-dark (%s) de resources/css/app.css. Os dois pintam '
+        . 'com --brand-navy-dark (%s) de resources/css/app.css. Os dois pintam '
         . 'a mesma superfície em momentos diferentes do carregamento: divergir faz '
         . 'a cor trocar sozinha quando o CSS termina de chegar.',
         $token


### PR DESCRIPTION
Fecha #69. Harvest v2, dimensão 6 (UI) — candidato **F1**, pré-requisito de metade da célula.

`harvest: ctfinance @b8c6d57` — o diagnóstico veio da leitura comparada. **O ctfinance tem a mesma colisão e não a resolveu**; a prova do mecanismo veio de um bloco que ele escreveu *de propósito* (`app.css:299-311`, remapeando `--color-cyan-*` num `:root` justamente por saber que o não-layerizado vence).

## O defeito

`--color-primary` e `--color-accent` estavam declarados **duas vezes**: uma dentro do `@theme` (`var(--primary)` / `var(--accent)`) e outra num `:root` **sem layer**, com hex cru. Declaração fora de layer vence declaração em `@layer`.

| | Antes | Depois |
| - | ----- | ------ |
| `bg-primary` / `text-primary` (claro) | `#1f3c57` | `#0f2a44` (o `--primary` de verdade) |
| `bg-primary` / `text-primary` (escuro) | `#1f3c57` — **o mesmo** | `#379bcb` |
| `text-primary` no escuro | **1.28:1** | 4.68:1 |
| `hover:bg-accent` (ghost/outline) | `#379bcb` saturado, igual nos dois temas | o azul pálido do tema |

O comentário `/* Buttons/CTAs should be high-contrast in dark mode */` (`app.css:169`) descrevia um **efeito morto**: o `.dark { --primary }` nunca chegava a utilitário nenhum. Alcance medido: **59 matches em 39 linhas**.

## O que mudou

- A paleta crua sai do namespace: `--color-primary-dark` → `--brand-navy-dark`, `--color-primary-darker` → `--brand-navy-soft`, `--color-accent-light` → `--brand-cyan-light`, `--color-accent` → `--brand-cyan`, `--color-muted-light` → `--brand-gray`.
- **`--color-primary: #1f3c57` foi APAGADO, não renomeado.** Medi: **zero consumidores**. Existia só para sombrear a entrada do `@theme`.
- **Recalibração medida.** Com a colisão desfeita, o `--primary` do escuro passa a valer `#379bcb` de verdade — e branco sobre ele dá **3.13:1**, que reprova AA. O `--primary-foreground` do escuro passa a `--brand-navy-dark`: **4.68:1**. Sem esta parte, o "conserto" embarcaria uma regressão de contraste.

## Verificação no artefato, não no fonte

Rodei o build e medi o CSS compilado:

```
--color-primary:  2 declarações → 1, dentro de @layer theme
--color-accent:   2 declarações → 1, dentro de @layer theme
```

## Verificação por mutação

| Mutação | Resultado |
| ------- | --------- |
| Recriar `--color-primary: #1f3c57` no `:root` | ⨯ falha |
| Voltar o `--primary-foreground` do escuro para branco | ⨯ falha (3.13:1) |
| Igualar o `--primary` do escuro ao do claro | ⨯ 2 falham |

## O guard-rail

`resources/js/test/styles/theme-tokens.test.ts` (novo, 18 testes) resolve as cadeias de `var()` e **calcula o contraste**, em vez de listar nomes de token como faz o teste equivalente do ctfinance (que apodrece). Assere: nenhum `--color-*` fora do `@theme`; o `@theme` só mapeia para `var()`, nunca para literal; e 4.5:1 em cada par `--X`/`--X-foreground` nos dois temas.

Mais `.ai/rules/css.md` (novo — não existia glob para `resources/css/**`).

## Duas coisas que ficaram de fora, de propósito

**1. `@theme inline` não entrou.** Era o mecanismo que a análise recomendava, e eu cheguei a aplicá-lo — mas ele **quebra dois consumidores vivos**: `lib/toast-config.ts:16` lê `var(--font-sans)`, e `app.css:89` usa `var(--color-border, currentColor)` como borda padrão; com `inline` o Tailwind deixa de emitir essas variáveis e as duas caem no fallback em silêncio. Como desfazer a colisão já resolve o problema (verificado no artefato), o `inline` seria raio extra sem ganho.

**2. A terceira colisão, do `@radix-ui/themes`, continua viva** e está medida: o artefato tem **3 declarações de `--color-background`, duas fora de qualquer layer**, vindas da folha do Radix, e `.bg-background` lê a sequestrada. Não entrou aqui porque a cura é ordenar layer de folha de terceiro — mecanismo diferente, raio visual grande, e o mesmo `@import` já é alvo do candidato **F6** (a folha pesa 812 KB e entra em toda página, inclusive as de auth que não usam Radix). Os dois devem viajar juntos. Está registrado como dívida em `.ai/rules/css.md`.

## Dívida conhecida que o teste passa a segurar

`destructive` no escuro dá **3.67:1** e não passa — defeito anterior a esta fatia. Não dá para pagar aqui: o mesmo token serve de preenchimento (quer ser escuro, para texto branco) e de cor de texto sobre o canvas escuro (quer ser claro). Medi: escurecer para `#e11d48` leva o botão a 4.70 mas **derruba `text-destructive` de 3.99 para 3.12** — e é justamente `text-destructive` que a fatia E6 vai passar a usar no `InputError`. A cura é separar preenchimento de texto (candidato **F3**). Até lá o par entra como **catraca**: o teste impede piorar e falha também se alguém consertar sem mover o par para a tabela principal.

## De brinde

O guard da fatia D4 (`InlineThemeBackgroundTest`) **pegou o rename** — ele assere que o fundo inline do blade bate com o token do `app.css`, e ficou vermelho até eu atualizar as duas pontas. Guard-rail de fatia anterior pagando o próprio custo.

## Gates

`composer ci:check` exit 0 — 364 testes / 1896 asserções. `corepack pnpm ci:check` exit 0.

**Vale seu olho antes do merge:** esta fatia muda cor de verdade em tela (`bg-primary` no claro fica mais escuro, e no escuro vira ciano com texto navy).