### PR TITLE
[75]: fix(tema): fecha os dois buracos do tema fora do React

### DIFF
--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -11,6 +11,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | app/Events/** | .ai/rules/events.md |
 | resources/css/** | .ai/rules/css.md |
 | resources/js/** | .ai/rules/js.md |
+| resources/views/** | .ai/rules/views.md |
 | app/Listeners/** | .ai/rules/listeners.md |
 | app/Http/Middleware/** | .ai/rules/middleware.md |
 | app/Models/** | .ai/rules/models.md |

--- a/.ai/rules/views.md
+++ b/.ai/rules/views.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - 'resources/views/**'
+---
+
+# Views
+
+## Blade que pinta sem o `app.css` usa literal, e o literal espelha o token
+Duas superfícies são pintadas por CSS inline e não pelo `app.css`: o bloco de estilo no topo de `app.blade.php` (que cobre a janela antes de o `@vite` entregar o CSS) e `errors/500.blade.php` (o fallback do `catch` de `bootstrap/app.php`, renderizado justamente quando o manifest/build quebrou — ali não existe `app.css` nenhum). Nas duas, um `var(--token)` declarado no `app.css` é inválido em computed-value time exatamente na janela que o bloco existe para cobrir, e o fundo fica sem cor. O preço do literal é duplicação: `tests/Unit/Theme/InlineThemeBackgroundTest.php` cobra que o hex continue igual ao `--brand-navy-dark`. Superfície nova pintada fora do `app.css` entra nesse teste no mesmo commit — o 500 tinha divergido para `#0f172a` (o slate-900 do Tailwind) sem ninguém ver, porque a guarda nascera olhando um arquivo só.
+
+## `color-scheme` acompanha a classe `.dark`, nunca um valor calculado no servidor
+O cromo nativo (barra de rolagem, controles de formulário, campo de data) segue o `color-scheme`. Se ele vier só do `<meta name="color-scheme">`, congela no valor que o servidor renderizou: quem troca o tema em `use-appearance.tsx` — que alterna a classe `.dark` — fica com o cromo do tema anterior até dar reload. Declarar `color-scheme: light` em `html` e `color-scheme: dark` em `html.dark` no mesmo bloco inline resolve sem uma linha de JS e já no primeiro paint, porque a classe é justamente o que muda. O `<meta>` fica como declaração precoce, e os dois concordam.
+
+## A página de último recurso não ganha dependência nova
+`errors/500.blade.php` existe para o caso de tudo o mais ter falhado: sem Vite, sem app.css, possivelmente sem middleware. Cada dependência acrescentada ali é uma chance a mais de ela também não aparecer. O tema vem de `$appearance` (publicado por `HandleAppearance` via `View::share`, com o cookie fora do `encryptCookies`) sempre com `?? 'system'` e com o valor restrito a `light|dark|system` antes de entrar no HTML — o `system` cai no `prefers-color-scheme`. Sem JS, sem asset, sem consulta ao banco.

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -27,18 +27,26 @@
         Os dois valores são literais de propósito. Este bloco existe para pintar
         o fundo ANTES de o app.css chegar (ele vem pelo @vite lá embaixo), então
         referenciar um token declarado no app.css o deixa inválido exatamente na
-        janela em que ele deveria valer. O hex escuro espelha
-        `--color-primary-dark` de resources/css/app.css, e um teste trava a
-        sincronia entre os dois.
+        janela em que ele deveria valer. O hex escuro espelha `--brand-navy-dark`
+        de resources/css/app.css, e um teste trava a sincronia entre os dois.
+
+        O `color-scheme` mora aqui, e não só no <meta> acima, porque ele precisa
+        seguir a CLASSE `.dark` — que é o que muda quando o usuário troca de
+        tema em `use-appearance.tsx`. O <meta> é calculado no servidor e
+        congela: quem alternasse o tema ficava com barra de rolagem e controles
+        nativos do tema anterior até dar reload. Preso à classe, acompanha de
+        graça, sem uma linha de JS e já no primeiro paint.
     --}}
     <style >
         html {
             background-color: white;
+            color-scheme: light;
             transition: background-color 0.2s ease;
         }
 
         html.dark {
             background-color: #0f2a44;
+            color-scheme: dark;
             transition: background-color 0.2s ease;
         }
     </style >

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,12 +1,33 @@
-<!DOCTYPE html>
-<html lang="pt-BR">
+{{--
+    Fallback de último recurso: renderizado no `catch` de bootstrap/app.php,
+    quando o próprio render Inertia falha — tipicamente manifest/build quebrado.
+    Ou seja, é a única página do app que roda SEM o app.css. Como o bloco de
+    estilo inline de app.blade.php, ele carrega literais, e os literais têm de
+    espelhar os tokens; tests/Unit/Theme/InlineThemeBackgroundTest.php cobra a
+    sincronia dos dois arquivos.
+
+    O tema vem da MESMA fonte do resto do app: `$appearance`, publicado por
+    HandleAppearance via View::share (o cookie está fora do encryptCookies).
+    Antes esta página decidia só por `prefers-color-scheme`, então quem tinha
+    escolhido "escuro" com o sistema em claro recebia uma página branca. O modo
+    `system` segue caindo na media query. Sem JS: numa página que existe para o
+    caso de tudo ter quebrado, cada dependência a menos é uma chance a mais de
+    ela aparecer.
+--}}
+@php($theme = in_array($appearance ?? 'system', ['light', 'dark'], true) ? $appearance : 'system')
+    <!DOCTYPE html>
+<html lang="pt-BR" class="{{ $theme }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Erro interno</title>
     <style>
-        :root {
-            color-scheme: light dark;
+        html {
+            color-scheme: light;
+        }
+
+        html.dark {
+            color-scheme: dark;
         }
 
         body {
@@ -20,10 +41,19 @@
             color: #0f2a44;
         }
 
+        html.dark body {
+            background: #0f2a44;
+            color: #ffffff;
+        }
+
         @media (prefers-color-scheme: dark) {
-            body {
-                background: #0f172a;
-                color: #e2e8f0;
+            html.system {
+                color-scheme: dark;
+            }
+
+            html.system body {
+                background: #0f2a44;
+                color: #ffffff;
             }
         }
 

--- a/tests/Feature/ErrorPagesTest.php
+++ b/tests/Feature/ErrorPagesTest.php
@@ -56,3 +56,27 @@ it('redirects back with a flash when the session expires (419)', function() {
         ->assertRedirect(route('login'))
         ->assertInertiaFlash('error');
 });
+
+/*
+ * O 500 em Blade é o fallback do `catch` do respond(): ele só aparece quando o
+ * próprio render Inertia falha, tipicamente com manifest/build quebrado. Como
+ * não há app.css nessa hora, ele carrega o próprio tema — e decidia por
+ * `prefers-color-scheme`, enquanto o app decide por CLASSE, vinda do cookie.
+ * Quem tinha escolhido "escuro" com o sistema em claro recebia página branca.
+ */
+it('paints the last-resort 500 page with the appearance the user chose', function(string $appearance, string $esperado) {
+    $this->view('errors.500', ['appearance' => $appearance])
+        ->assertSee('<html lang="pt-BR" class="' . $esperado . '">', false);
+})->with([
+    'escuro explícito' => ['dark', 'dark'],
+    'claro explícito'  => ['light', 'light'],
+    'segue o sistema'  => ['system', 'system'],
+    'valor inválido'   => ['dark" onload="alert(1)', 'system'],
+]);
+
+it('falls back to system when the appearance never got shared', function() {
+    // O respond() pode disparar ANTES de HandleAppearance rodar (exceção em
+    // provider, por exemplo) — aí $appearance simplesmente não existe na view.
+    $this->view('errors.500')
+        ->assertSee('<html lang="pt-BR" class="system">', false);
+});

--- a/tests/Unit/Theme/InlineThemeBackgroundTest.php
+++ b/tests/Unit/Theme/InlineThemeBackgroundTest.php
@@ -4,32 +4,115 @@ declare(strict_types = 1);
 
 /*
 |--------------------------------------------------------------------------
-| Fundo do tema antes do CSS chegar
+| Tema fora do React — os dois blades que pintam sem o app.css
 |--------------------------------------------------------------------------
 |
-| O `<style>` inline de resources/views/app.blade.php existe para pintar o
-| fundo antes de o app.css ser baixado — ele fica no topo do <head>, e o CSS
-| só entra pelo @vite mais abaixo. Isso o obriga a usar valores literais: um
-| `var(--token)` declarado no app.css é inválido em computed-value time
-| justamente na janela que o bloco existe para cobrir, e o fundo fica sem cor.
+| Duas superfícies do app são pintadas por CSS inline, não pelo app.css:
 |
-| Foi o que aconteceu em c2ffbc7 (um commit de fontes): a linha escura virou
-| `var(--color-primary-dark)` — hoje `--brand-navy-dark` — e ninguém viu, porque em produção o CSS é
-| render-blocking e o token já existe no primeiro paint. A janela real é o
-| `composer dev`, onde o Vite injeta o CSS por JS.
+| 1. resources/views/app.blade.php — o <style> no topo do <head> pinta o fundo
+|    ANTES de o app.css ser baixado (ele vem pelo @vite lá embaixo).
+| 2. resources/views/errors/500.blade.php — o fallback do `catch` de
+|    bootstrap/app.php, renderizado quando o próprio render Inertia falha.
+|    Tipicamente manifest/build quebrado: aqui não existe app.css nenhum.
+|
+| As duas são obrigadas a usar valores literais — um `var(--token)` declarado no
+| app.css é inválido em computed-value time exatamente na janela que estes
+| blocos existem para cobrir, e o fundo fica sem cor. Foi o que aconteceu em
+| c2ffbc7 (um commit de fontes): a linha escura virou `var(--color-primary-dark)`
+| e ninguém viu, porque em produção o CSS é render-blocking e o token já existe
+| no primeiro paint. A janela real é o `composer dev`, onde o Vite injeta o CSS
+| por JS.
 |
 | O preço do literal é duplicação, e é isso que esta guarda cobra: o hex do
-| blade tem de continuar igual ao token do app.css.
+| blade tem de continuar igual ao token do app.css. A guarda nasceu cobrindo só
+| o app.blade.php, e o 500 divergiu sem ninguém ver — pintava #0f172a (slate-900
+| do Tailwind) onde o app pinta #0f2a44. Agora ela cobre os dois.
 |
 */
 
-function inlineThemeStyleBlock(): string
+/** @return array<string, string> nome legível => caminho do blade */
+function themedBlades(): array
 {
-    $blade = (string) file_get_contents(dirname(__DIR__, 3) . '/resources/views/app.blade.php');
+    $root = dirname(__DIR__, 3);
 
-    preg_match('/<style\s*>(.*?)<\/style\s*>/s', $blade, $matches);
+    return [
+        'app.blade.php'        => $root . '/resources/views/app.blade.php',
+        'errors/500.blade.php' => $root . '/resources/views/errors/500.blade.php',
+    ];
+}
+
+function themeStyleBlock(string $nome): string
+{
+    $blade = themedBlades()[$nome];
+
+    // Os comentários Blade saem antes de procurar a tag: um deles CITA a tag de
+    // estilo em prosa, e o regex mordia a citação em vez do bloco real —
+    // devolvendo um "CSS" que continha qualquer coisa que o comentário dissesse.
+    $conteudo = preg_replace('/\{\{--.*?--\}\}/s', '', (string) file_get_contents($blade)) ?? '';
+
+    preg_match('/<style\s*>(.*?)<\/style\s*>/s', $conteudo, $matches);
 
     return $matches[1] ?? '';
+}
+
+/**
+ * Regras do bloco de estilo, achatadas: o abre-`@media` sai fora para as
+ * regras aninhadas virarem topo de nível.
+ *
+ * @return array<int, array{seletor: string, corpo: string}>
+ */
+function themeRules(string $nome): array
+{
+    $css = preg_replace('/@media[^{]*\{/', '', themeStyleBlock($nome)) ?? '';
+
+    preg_match_all('/([^{}]+)\{([^{}]*)\}/', $css, $regras, PREG_SET_ORDER);
+
+    return array_map(fn(array $r): array => [
+        'seletor' => trim(preg_replace('/\s+/', ' ', $r[1]) ?? ''),
+        'corpo'   => $r[2],
+    ], $regras);
+}
+
+/**
+ * Valor de uma propriedade nas regras cujo seletor casa com o filtro.
+ *
+ * Existe porque a versão anterior desta guarda perguntava só "o texto aparece
+ * em algum lugar do bloco?" — e isso passava verde com o defeito no lugar: o
+ * hex do token aparecia como `color` do tema CLARO, e o `color-scheme: dark`
+ * aparecia dentro do `@media`. Medir a declaração da regra certa é o que
+ * transforma a busca em guarda.
+ *
+ * @return array<string, string> seletor => valor
+ */
+function themeDeclarations(string $nome, string $propriedade, callable $seletorCasa): array
+{
+    $encontradas = [];
+
+    foreach (themeRules($nome) as ['seletor' => $seletor, 'corpo' => $corpo]) {
+        if (!$seletorCasa($seletor)) {
+            continue;
+        }
+
+        if (preg_match('/(?:^|\s)' . preg_quote($propriedade, '/') . ':\s*([^;]+);/', $corpo, $decl) === 1) {
+            $encontradas[$seletor] = trim($decl[1]);
+        }
+    }
+
+    return $encontradas;
+}
+
+/** Seletores de tema escuro: `.dark` explícito ou o `.system` dentro do `@media`. */
+function ehSeletorEscuro(string $seletor): bool
+{
+    return str_contains($seletor, '.dark') || str_contains($seletor, '.system');
+}
+
+/** @return array<string, string> */
+function darkBackgroundDeclarations(string $nome): array
+{
+    $fundos = themeDeclarations($nome, 'background', ehSeletorEscuro(...));
+
+    return $fundos + themeDeclarations($nome, 'background-color', ehSeletorEscuro(...));
 }
 
 function appCssToken(string $token): string
@@ -41,31 +124,58 @@ function appCssToken(string $token): string
     return trim($matches[1] ?? '');
 }
 
-it('reads both files', function(): void {
-    expect(inlineThemeStyleBlock())->not->toBe('')
-        ->and(appCssToken('brand-navy-dark'))->not->toBe('');
+it('reads every themed blade and the css token', function(): void {
+    expect(appCssToken('brand-navy-dark'))->not->toBe('');
+
+    foreach (themedBlades() as $nome => $caminho) {
+        expect(themeStyleBlock($nome))->not->toBe('', "O <style> de {$nome} não foi encontrado");
+    }
 });
 
-it('paints the dark background with a literal, never a css variable', function(): void {
-    expect(str_contains(inlineThemeStyleBlock(), 'var(--'))->toBe(
+it('paints the dark background with a literal, never a css variable', function(string $nome): void {
+    expect(str_contains(themeStyleBlock($nome), 'var(--'))->toBe(
         false,
-        'O <style> inline roda antes do app.css: um var() aqui fica sem valor '
-        . 'exatamente na janela que este bloco existe para cobrir. Use o literal '
-        . 'e deixe o teste de sincronia cobrar a igualdade com o token.'
+        "O <style> inline de {$nome} roda antes (ou na ausência) do app.css: um var() aqui "
+        . 'fica sem valor exatamente na janela que este bloco existe para cobrir. Use o '
+        . 'literal e deixe o teste de sincronia cobrar a igualdade com o token.'
     );
-});
+})->with(fn() => array_keys(themedBlades()));
 
-it('keeps the inline dark background in sync with the app.css token', function(): void {
-    $token = appCssToken('brand-navy-dark');
+it('keeps the inline dark background in sync with the app.css token', function(string $nome): void {
+    $token       = appCssToken('brand-navy-dark');
+    $declaracoes = darkBackgroundDeclarations($nome);
 
-    expect(str_contains(inlineThemeStyleBlock(), $token))->toBe(true, sprintf(
-        'O fundo escuro inline de resources/views/app.blade.php saiu de sincronia '
-        . 'com --brand-navy-dark (%s) de resources/css/app.css. Os dois pintam '
-        . 'a mesma superfície em momentos diferentes do carregamento: divergir faz '
-        . 'a cor trocar sozinha quando o CSS termina de chegar.',
-        $token
-    ));
-});
+    expect($declaracoes)->not->toBeEmpty(
+        "Nenhuma regra de tema escuro com fundo foi encontrada em {$nome} — o seletor mudou "
+        . 'e esta guarda ficaria vazia, passando por acidente.'
+    );
+
+    foreach ($declaracoes as $seletor => $valor) {
+        expect($valor)->toBe($token, sprintf(
+            'O fundo escuro de `%s` em %s (%s) saiu de sincronia com --brand-navy-dark (%s) '
+            . 'de resources/css/app.css. Os dois pintam a mesma superfície em momentos '
+            . 'diferentes do carregamento: divergir faz a cor trocar sozinha quando o CSS '
+            . 'termina de chegar.',
+            $seletor,
+            $nome,
+            $valor,
+            $token
+        ));
+    }
+})->with(fn() => array_keys(themedBlades()));
+
+it('declares color-scheme for both themes so native chrome follows the class', function(string $nome): void {
+    // Preso à CLASSE, e não a um valor calculado no servidor: é a classe que
+    // muda quando o usuário troca de tema, então o cromo nativo (barra de
+    // rolagem, controles de formulário) acompanha sem JS e sem reload.
+    $claro  = themeDeclarations($nome, 'color-scheme', fn(string $s): bool => !ehSeletorEscuro($s));
+    $escuro = themeDeclarations($nome, 'color-scheme', fn(string $s): bool => str_contains($s, '.dark'));
+
+    // Via `in_array` e não `toContain`: o segundo argumento de `toContain` é
+    // OUTRO needle no Pest, não a mensagem de falha.
+    expect(in_array('light', $claro, true))->toBe(true, "Falta uma regra de tema claro declarando color-scheme em {$nome}")
+        ->and(in_array('dark', $escuro, true))->toBe(true, "Falta uma regra `.dark` declarando color-scheme em {$nome}");
+})->with(fn() => array_keys(themedBlades()));
 
 it('declares a color-scheme meta so native chrome follows the theme', function(): void {
     $blade = (string) file_get_contents(dirname(__DIR__, 3) . '/resources/views/app.blade.php');


### PR DESCRIPTION
Fecha #75 · harvest v2, dimensão 6 (UI) do **ctfinance** @ `b8c6d57` — candidatos **F42** e **F35**. Os dois fecham pontas deixadas pela fatia **D4** (PR #62, já mesclada).

## F42 — o 500 de último recurso pintava outro tema

`resources/views/errors/500.blade.php` é o fallback do `catch` de `bootstrap/app.php:65`, renderizado quando o próprio render Inertia falha — tipicamente manifest/build quebrado. É **a única página do app que roda sem o `app.css`**, então carrega os próprios literais. Eles tinham divergido:

| superfície | antes | depois |
| ---------- | ----- | ------ |
| fundo escuro | `#0f172a` (slate-900 do Tailwind) | `#0f2a44` (`--brand-navy-dark`) |
| texto escuro | `#e2e8f0` | `#ffffff` (`--foreground`) |

O guard do D4 (`InlineThemeBackgroundTest`) existe exatamente para cobrar essa sincronia — mas olhava só o `app.blade.php`. Agora cobre os dois.

**E havia uma divergência mais funda que a cor:** o 500 decidia o tema por `@media (prefers-color-scheme: dark)`, enquanto o app decide por **classe** `.dark`, vinda do cookie. Quem escolheu "escuro" com o sistema em claro recebia uma página de erro **branca**. Passa a ler `$appearance` — já publicado por `HandleAppearance` via `View::share`, e o cookie está fora do `encryptCookies` — com o valor restrito a `light|dark|system`; o `system` segue caindo na media query.

Sem JS e sem asset novo: numa página que existe para o caso de tudo ter quebrado, cada dependência a menos é uma chance a mais de ela aparecer.

## F35 — o cromo nativo não acompanhava a troca de tema

`<meta name="color-scheme">` é calculado no servidor (`app.blade.php:8`) e **congela**: `use-appearance.tsx:22-26` alterna a classe `.dark` e não toca nele. Barra de rolagem, controles de formulário e campos de data ficavam do tema anterior até o reload.

A correção **não** foi mexer no meta por JS, e sim declarar `color-scheme` no mesmo bloco inline que já pinta o fundo, preso a `html` / `html.dark`. A classe é justamente o que muda ao trocar de tema, então o cromo acompanha sem uma linha de JS e já no primeiro paint. O `<meta>` fica como declaração precoce, e os dois concordam em todos os casos.

## Evidência

`tests/Unit/Theme/InlineThemeBackgroundTest.php` passa a parametrizar as guardas sobre os **dois** blades (literal, sincronia com o token, `color-scheme` nos dois temas), e `tests/Feature/ErrorPagesTest.php` ganha o render real do 500 nos três modos + valor inválido + `$appearance` ausente.

Verificado **por mutação**, não só por passar verde:

| Mutação aplicada | Resultado |
| ---------------- | --------- |
| Fundo escuro do 500 volta ao slate-900 | ⨯ falha |
| Só a regra do `@media` (system) diverge | ⨯ falha |
| Fundo escuro do `app.blade` diverge | ⨯ falha |
| Fundo escuro do `app.blade` vira `var()` | ⨯ 2 falham |
| 500 ignora `$appearance` | ⨯ 5 falham |
| 500 sem allowlist de valores | ⨯ 5 falham |
| Tira o `color-scheme` escuro do `app.blade` | ⨯ falha |
| Tira o `color-scheme` da regra `.dark` do 500 | ⨯ falha |
| Tira o `color-scheme` claro do 500 | ⨯ falha |

**Quatro dessas só passaram a morder depois de a guarda mudar de forma.** Ela perguntava "esse texto aparece no bloco de estilo?" — e isso passava verde **com o defeito no lugar**: o hex do token aparecia como `color` do tema claro, e o `color-scheme: dark` aparecia dentro do `@media`. A guarda agora achata as regras e mede a declaração da regra certa.

Gates: `composer ci:check` **373 testes / 1911 asserções** e `corepack pnpm ci:check` **30 arquivos / 204 testes**, ambos exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)