### PR TITLE
[77]: fix(a11y): declara o type dos botões e liga a regra que cobra

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,6 +51,11 @@ export default [
             'react/react-in-jsx-scope': 'off',
             'react/prop-types': 'off',
             'react/no-unescaped-entities': 'off',
+            // O default de `<button>` no HTML é `type="submit"`: um botão sem
+            // type declarado submete o formulário que por acaso o envolver. É
+            // latente até alguém reusar o componente dentro de um <form> — e aí
+            // o clique faz duas coisas. A regra cobra o atributo explícito.
+            'react/button-has-type': 'error',
         },
         settings: {
             react: {

--- a/resources/js/components/appearance-tabs.tsx
+++ b/resources/js/components/appearance-tabs.tsx
@@ -17,6 +17,7 @@ export default function AppearanceToggleTab({ className = '', ...props }: HTMLAt
             {tabs.map(({ value, icon: Icon, label }) => (
                 <button
                     key={value}
+                    type="button"
                     onClick={() => updateAppearance(value)}
                     className={cn(
                         'flex items-center rounded-md px-3.5 py-1.5 transition-colors',

--- a/resources/js/components/data-table/filter-toggle.tsx
+++ b/resources/js/components/data-table/filter-toggle.tsx
@@ -9,6 +9,7 @@ import { SlidersHorizontal } from 'lucide-react';
 export function FilterToggle({ isOpen, onToggle, label = 'Filtros', className, activeFiltersCount = 0 }: FilterToggleProps) {
     return (
         <button
+            type="button"
             onClick={onToggle}
             className={cn(
                 'flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-all',

--- a/resources/js/components/ui/sidebar.tsx
+++ b/resources/js/components/ui/sidebar.tsx
@@ -279,6 +279,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
 
   return (
     <button
+      type="button"
       data-sidebar="rail"
       data-slot="sidebar-rail"
       aria-label="Abrir ou fechar o menu lateral"


### PR DESCRIPTION
Fecha #77 · harvest v2, dimensão 6 (UI) do **ctfinance** @ `b8c6d57` — candidato **F23**.

## O defeito

O default de `<button>` no HTML é `type="submit"`. Três botões de produção não declaravam `type`:

| arquivo | linha |
| ------- | ----- |
| `components/appearance-tabs.tsx` | 18 |
| `components/data-table/filter-toggle.tsx` | 11 |
| `components/ui/sidebar.tsx` | 281 (o `SidebarRail`) |

**Severidade honesta, porque a medição contradiz o instinto:** hoje **nenhum dos três vive dentro de um `<form>`** — `pages/settings/appearance.tsx` e `pages/users/index.tsx` não têm formulário, e o rail fica no shell. Então isto é **latente, não um bug vivo**. O dano chega no dia em que um desses componentes for reusado dentro de um form e o clique passar a fazer duas coisas: a ação dele e o submit.

É por isso que a fatia vale mais pela regra que pelos três atributos.

## O que entrou

1. `type="button"` explícito nos três.
2. `react/button-has-type` como `error` no `eslint.config.js`. O plugin `react` já estava configurado (o arquivo desliga três regras dele), então é uma linha — e o gate passa a cobrar sozinho dentro de `corepack pnpm ci:check`.

**Sem regra em `.ai/rules` de propósito.** O ESLint *é* o teste aqui e falha o gate; escrever a mesma coisa em prosa criaria uma segunda fonte para o mesmo fato, que é justamente o que as regras da casa mandam evitar.

## Evidência

O lint é a evidência, e foi verificado **por mutação**:

| Mutação aplicada | Resultado |
| ---------------- | --------- |
| Tira o `type` do `filter-toggle` | ⨯ `11:9 error Missing an explicit type attribute for button` |
| Desliga a regra e repete a mesma mutação | ✓ passa verde — prova que é a regra que cobra, e não um acaso do formatador |

Gates: `composer ci:check` 364 testes / 1896 asserções e `corepack pnpm ci:check` 30 arquivos / 204 testes, ambos exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)