### PR TITLE
[79]: fix(seguranca): um manager lia CPF e notas internas do admin

### DIFF
--- a/.ai/rules/resources.md
+++ b/.ai/rules/resources.md
@@ -7,3 +7,6 @@ paths:
 
 ## Relações em Resources só via whenLoaded()
 Em Resources, exponha relações exclusivamente via whenLoaded() (e relationLoaded() para aninhadas) — nunca acesso incondicional. Ao resolver coleções manualmente use resolve(), não toArray(), para que relações não carregadas sejam omitidas; declare public bool $preserveKeys = true.
+
+## Campo sensível passa por policy, e a régua não mora no Resource
+Permissão diz *se a tela abre*; ela não diz *quanto daquela linha a pessoa pode ler*. `manage_users` vai para `manager` (70) na matriz do seeder, então um Resource que devolvesse CPF, telefones e notas internas sem condicional entregava a PII do administrador (90) ao gerente — foi exatamente o que aconteceu com o `UserResource`, com o teto de autoridade existindo só a partir de `update()`. Campo sensível novo nasce atrás de `Gate::forUser($request->user())->allows('viewSensitive', $this->resource)`. A régua fica na policy, nunca inline no Resource: um só lugar responde "quem manda em quem", e é ele que resolve o **ator real** por trás de uma impersonation (`effectiveActor()`), porque a permissão se lê na persona mas o teto é do humano. Prefira **mascarar** a omitir quando o campo serve para reconhecer a linha (`CpfFormatter::mask()`), e cubra o par: quem vê e quem não vê.

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -3,8 +3,10 @@
 namespace App\Http\Resources;
 
 use App\Models\User;
+use App\Support\Br\CpfFormatter;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @mixin User
@@ -20,15 +22,28 @@ class UserResource extends JsonResource
     {
         $currentUser = $request->user();
 
+        /*
+         * O teto de PII. `manage_users` é o que abre este resource, e ele vai
+         * para `manager` (70) na matriz do seeder — sem esta linha, o gerente
+         * lia CPF, telefones e notas internas do administrador (90) em claro.
+         * A régua é a mesma da mutação e mora na policy, não aqui: um só lugar
+         * responde "quem manda em quem", e ele já resolve o ator real por trás
+         * de uma impersonation.
+         */
+        $veSensiveis = $currentUser !== null && Gate::forUser($currentUser)->allows('viewSensitive', $this->resource);
+
         return [
-            'id'         => $this->id,
-            'name'       => $this->name,
-            'email'      => $this->email,
-            'cpf_cnpj'   => $this->cpf_cnpj,
-            'phone'      => $this->phone,
-            'mobile'     => $this->mobile,
+            'id'    => $this->id,
+            'name'  => $this->name,
+            'email' => $this->email,
+            // Mascarado, não omitido: a tela de listagem usa o CPF para o
+            // operador reconhecer a linha, e os dois últimos dígitos bastam
+            // para isso sem entregar o documento.
+            'cpf_cnpj'   => $veSensiveis ? $this->cpf_cnpj : CpfFormatter::mask($this->cpf_cnpj),
+            'phone'      => $veSensiveis ? $this->phone : null,
+            'mobile'     => $veSensiveis ? $this->mobile : null,
             'is_active'  => $this->is_active,
-            'user_notes' => $this->user_notes,
+            'user_notes' => $veSensiveis ? $this->user_notes : null,
             'role'       => $this->whenLoaded('role', function() {
                 if ($this->role === null) {
                     return null;

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -115,6 +115,34 @@ class UserPolicy
     }
 
     /**
+     * Ver os dados sensíveis de outra conta: CPF/CNPJ, telefones e notas
+     * internas.
+     *
+     * O teto de autoridade desta classe começava em `update()`: `viewAny()` e
+     * `view()` eram `manage_users` puro, sem comparar prioridade. Só que o
+     * `UserResource` devolvia PII sem condicional nenhuma, e `manage_users`
+     * vai para `manager` (70) na matriz do seeder — então o gerente abria
+     * `/users` e lia o CPF, os telefones e as notas internas do administrador
+     * (90) em claro. Mutação estava travada; **leitura** ficou de fora.
+     *
+     * Mesma régua da mutação, para não haver duas respostas para a mesma
+     * pergunta: a si mesmo sempre, `super_user` sempre, e no resto prioridade
+     * estritamente maior — medida no ator REAL, não na persona impersonada.
+     */
+    public function viewSensitive(User $user, User $model): bool
+    {
+        if (!$user->hasPermissionTo('manage_users')) {
+            return false;
+        }
+
+        if ($this->effectiveActor($user)->id === $model->id) {
+            return true;
+        }
+
+        return $this->outranks($user, $model);
+    }
+
+    /**
      * Atribuir/remover o CARGO de outro usuário (rotas `user.assign-role` e
      * `user.revoke-role`). Essas rotas checavam o cargo NOVO contra o ator e
      * nunca o cargo ATUAL do alvo: um gerente (70) rebaixava o administrador

--- a/tests/Feature/User/UserResourceSensitiveCeilingTest.php
+++ b/tests/Feature/User/UserResourceSensitiveCeilingTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Enum\Roles;
+use App\Models\User;
+use App\Services\ImpersonationService;
+
+/*
+|--------------------------------------------------------------------------
+| Teto de PII do UserResource
+|--------------------------------------------------------------------------
+|
+| O teto de autoridade do RBAC começava em `update()`: `viewAny()`/`view()`
+| eram `manage_users` puro. Só que o `UserResource` devolvia `cpf_cnpj`,
+| `phone`, `mobile` e `user_notes` sem condicional nenhuma, e `manage_users`
+| vai para `manager` (70) na matriz do seeder.
+|
+| Resultado medido antes desta fatia: um gerente abria `/users` e lia o CPF, os
+| telefones e as notas internas do administrador (90) em claro. Mutação estava
+| travada; leitura tinha ficado de fora.
+|
+| A régua vive na policy (`viewSensitive`), não no resource — um só lugar
+| responde "quem manda em quem", e ele já resolve o ator REAL por trás de uma
+| impersonation.
+|
+*/
+
+/** Devolve a linha de `$alvo` dentro da prop `users` da listagem. */
+function linhaDaListagem(User $alvo): array
+{
+    $resposta = test()->get(route('users.index'));
+
+    $resposta->assertOk();
+
+    $linhas = collect($resposta->viewData('page')['props']['users'])
+        ->firstWhere('id', $alvo->id);
+
+    expect($linhas)->not->toBeNull("O alvo #{$alvo->id} não apareceu na listagem");
+
+    return $linhas;
+}
+
+it('hides the sensitive fields of someone the viewer does not outrank', function(): void {
+    $admin = userWithRole(Roles::ADMIN);
+    actingAsUserWithRole(Roles::MANAGER);
+
+    $linha = linhaDaListagem($admin);
+
+    expect($linha['cpf_cnpj'])->not->toBe($admin->cpf_cnpj)
+        ->and($linha['cpf_cnpj'])->toStartWith('***.***.***-')
+        ->and($linha['phone'])->toBeNull()
+        ->and($linha['mobile'])->toBeNull()
+        ->and($linha['user_notes'])->toBeNull();
+});
+
+it('keeps the masked cpf recognizable by its last two digits', function(): void {
+    // Mascarar em vez de omitir é decisão de UX: o operador precisa reconhecer
+    // a linha. Se virar `null`, esta asserção cai e a decisão volta à mesa.
+    $admin = userWithRole(Roles::ADMIN);
+    actingAsUserWithRole(Roles::MANAGER);
+
+    expect(linhaDaListagem($admin)['cpf_cnpj'])->toBe('***.***.***-' . substr((string) $admin->cpf_cnpj, -2));
+});
+
+it('shows the sensitive fields of someone the viewer outranks', function(): void {
+    $manager = userWithRole(Roles::MANAGER);
+    actingAsUserWithRole(Roles::ADMIN);
+
+    $linha = linhaDaListagem($manager);
+
+    expect($linha['cpf_cnpj'])->toBe($manager->cpf_cnpj)
+        ->and($linha['phone'])->toBe($manager->phone)
+        ->and($linha['mobile'])->toBe($manager->mobile)
+        ->and($linha['user_notes'])->toBe($manager->user_notes);
+});
+
+it('always shows the viewer their own sensitive fields', function(): void {
+    $eu = actingAsUserWithRole(Roles::MANAGER);
+
+    $linha = linhaDaListagem($eu);
+
+    expect($linha['cpf_cnpj'])->toBe($eu->cpf_cnpj)
+        ->and($linha['phone'])->toBe($eu->phone)
+        ->and($linha['user_notes'])->toBe($eu->user_notes);
+});
+
+it('lets a super user see everyone', function(): void {
+    $admin = userWithRole(Roles::ADMIN);
+    actingAsUserWithRole(Roles::SUPER_USER);
+
+    expect(linhaDaListagem($admin)['cpf_cnpj'])->toBe($admin->cpf_cnpj);
+});
+
+it('measures the ceiling on the real human, not on the impersonated persona', function(): void {
+    /*
+     * O ponto mais fácil de errar: quem manda é o humano por trás da sessão.
+     * Um admin vestindo um gerente continua enxergando como admin — senão
+     * impersonar viraria uma forma de PERDER acesso, e o inverso (persona
+     * acima do humano) viraria escada.
+     */
+    $admin   = actingAsUserWithRole(Roles::ADMIN);
+    $persona = userWithRole(Roles::MANAGER);
+    $alvo    = userWithRole(Roles::MANAGER);
+
+    // O alvo é PAR da persona (70 × 70): sozinha, ela não passaria do teto.
+    // Quem passa é o admin (90) por trás dela.
+    app(ImpersonationService::class)->start($admin, $persona);
+    test()->actingAs($persona);
+
+    expect(linhaDaListagem($alvo)['cpf_cnpj'])
+        ->toBe($alvo->cpf_cnpj, 'O admin por trás da persona deveria continuar vendo');
+});
+
+it('does not let a persona see what the human behind it cannot', function(): void {
+    // O outro lado do mesmo eixo, e o que importa para segurança: vestir uma
+    // persona ALTA não pode virar escada para quem está embaixo.
+    $manager = actingAsUserWithRole(Roles::MANAGER);
+    $persona = userWithRole(Roles::ADMIN);
+    $alvo    = userWithRole(Roles::ADMIN);
+
+    app(ImpersonationService::class)->start($manager, $persona);
+    test()->actingAs($persona);
+
+    expect(linhaDaListagem($alvo)['cpf_cnpj'])
+        ->toStartWith('***.***.***-', 'O gerente por trás da persona não alcança um admin');
+});
+
+it('does not let "myself" be read on the persona instead of the human', function(): void {
+    /*
+     * Nascido da passada de mutação: trocar `effectiveActor($user)->id` por
+     * `$user->id` na regra de "a si mesmo" passava verde com os testes acima,
+     * e é escalada — um gerente vestindo um administrador leria o CPF DESSE
+     * administrador, porque a persona é o próprio alvo.
+     */
+    $manager = actingAsUserWithRole(Roles::MANAGER);
+    $persona = userWithRole(Roles::ADMIN);
+
+    app(ImpersonationService::class)->start($manager, $persona);
+    test()->actingAs($persona);
+
+    expect(linhaDaListagem($persona)['cpf_cnpj'])
+        ->toStartWith('***.***.***-', 'A persona não é "si mesmo" para quem a veste');
+});
+
+it('denies the sensitive view to whoever lacks manage_users', function(): void {
+    // Redundante com o 403 da rota hoje, e de propósito: se um dia o resource
+    // for servido por uma tela sem `can:manage_users`, a policy segura.
+    $alvo   = userWithRole(Roles::MANAGER);
+    $viewer = actingAsUserWithRole(Roles::VIEWER);
+
+    expect($viewer->can('viewSensitive', $alvo))->toBeFalse();
+});
+
+it('requires manage_users even when the actor outranks the target', function(): void {
+    /*
+     * Também nascido da mutação: apagar a checagem de `manage_users` passava
+     * verde, porque o único caso negativo que havia (viewer 10 × manager 70)
+     * já era barrado pela prioridade. O caso que separa as duas condições é um
+     * ator SEM a permissão e ACIMA do alvo — `viewer` (10) sobre `visitor` (5).
+     */
+    $alvo   = userWithRole(Roles::VISITOR);
+    $viewer = actingAsUserWithRole(Roles::VIEWER);
+
+    expect($viewer->can('viewSensitive', $alvo))->toBeFalse();
+});


### PR DESCRIPTION
Fecha #79 · harvest v2, dimensão 1 (Segurança) do **spinmax** @ `e4ec01e` — candidato **S1**.

## O defeito

`app/Http/Resources/UserResource.php` devolvia `cpf_cnpj`, `phone`, `mobile` e `user_notes` **sem condicional nenhuma**. O teto de autoridade do RBAC só começava em `update()`: `UserPolicy::viewAny()`/`view()` eram `hasPermissionTo('manage_users')` puro, sem comparar prioridade. **Mutação estava travada; leitura ficou de fora.**

Com os cargos padrão do seeder isso não é teoria:

| Fato | Onde |
| ---- | ---- |
| `MANAGER` recebe `MANAGE_USERS` | `database/seeders/PermissionRoleSeeder.php:49-51` |
| `MANAGER` = 70 · `ADMIN` = 90 | `app/Enum/Roles.php:52-56` |
| A listagem não filtra por prioridade | `User/IndexController.php:28` |
| Zero testes tocavam o resource | `grep -rln UserResource tests/` → vazio |

⇒ **um gerente abria `/users` e lia o CPF, os telefones e as notas internas do administrador em claro.** O resource é servido em 5 controllers (`User/{Index,Show,Edit,ShowUserPermissions}`, `PermissionRole/Index`).

## O que entrou

`UserPolicy::viewSensitive()` — a régua vive **na policy, não no resource**: um só lugar responde "quem manda em quem", e ele já resolve o ator **real** por trás de uma impersonation (`effectiveActor()`), porque a permissão se lê na persona mas o teto é do humano. Mesma régua da mutação: a si mesmo, `super_user`, ou prioridade estritamente maior.

O CPF é **mascarado** com o `CpfFormatter::mask()` da casa em vez de omitido — a listagem usa os dois últimos dígitos para o operador reconhecer a linha. Os tipos TS já aceitavam `null` nos quatro campos, então não houve mudança de contrato.

**Correções de fato ao candidato:** o `share()` **não** usa o `UserResource` (monta array próprio), então o perfil do próprio usuário nunca esteve em risco; e o path `PermissionRole/ShowUserPermissionsController` não existe — é `User/ShowUserPermissionsController`.

## Evidência

10 testes novos em `tests/Feature/User/UserResourceSensitiveCeilingTest.php`, cobrindo o par (quem vê / quem não vê), o próprio usuário, `super_user`, e os **dois sentidos** da impersonation.

Verificado **por mutação** — e duas delas acharam buraco no próprio teste:

| Mutação aplicada | Resultado |
| ---------------- | --------- |
| Campos sem condicional (o defeito original) | ⨯ 3 falham |
| Teto frouxo: prioridade maior **ou igual** | ⨯ 3 falham |
| "A si mesmo" medido na **persona**, não no humano | ⨯ falha |
| Sem a checagem de `manage_users` | ⨯ falha |

**As duas últimas passaram verdes na primeira passada**, e valem registro:

- A terceira é escalada de verdade — um gerente vestindo um administrador leria o CPF **desse** administrador, porque a persona é o próprio alvo. Nenhum dos 8 testes originais discriminava esse caso.
- A quarta não tinha caso que separasse as duas condições: o único negativo existente (`viewer` 10 × `manager` 70) já era barrado pela prioridade, então apagar a permissão não mudava resultado. O caso que separa é ator **sem** a permissão e **acima** do alvo (`viewer` 10 × `visitor` 5).

Dois testes novos entraram antes do commit; sem a passada de mutação a fatia teria embarcado uma escalada e uma garantia não testada.

Gates: `composer ci:check` **374 testes / 1931 asserções** e `corepack pnpm ci:check` **30 arquivos / 204 testes**, ambos exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)