### PR TITLE
[83]: test(auth): prova que o lockout do login morde

### DIFF
--- a/.ai/rules/routes.md
+++ b/.ai/rules/routes.md
@@ -8,5 +8,8 @@ paths:
 ## Throttle sempre via limiter nomeado
 Toda rota com rate limit usa limiter nomeado (throttle:auth, throttle:impersonate, throttle:verification) definido em AppServiceProvider::configRateLimiting() — nunca throttle:N,M inline. Caso novo = novo RateLimiter::for() no provider + entrada no teste de contrato AuthRouteThrottleTest.
 
+## `POST login` fica sem throttle de rota de propósito
+É a única rota do grupo `guest` sem middleware de limite, e não é esquecimento: o limite dela mora no `LoginRequest` e é por **`email|ip`**, não por IP. Não acrescente `throttle:auth` ali — o limiter `auth` conta só por `$request->ip()`, então ele transformaria a defesa em arma, deixando um atacante trancar todo mundo que compartilha a mesma saída NAT. As quatro propriedades do lockout (senha correta segue recusada durante o bloqueio; as duas metades da chave importam; sucesso zera o contador; o evento `Lockout` dispara) estão travadas em `tests/Feature/Auth/LoginLockoutTest.php` — mexeu no `LoginRequest`, é lá que a conta é prestada.
+
 ## Rota de escrita autenticada declara autorização na própria rota
 Toda rota POST/PUT/PATCH/DELETE sob `auth` carrega `can:<permissão>` (ou o atributo `#[Authorize]`, que o L13 também aceita). Throttle não é autorização: uma rota com `throttle:` e sem `can:` está aberta a qualquer usuário logado. A única exceção é self-service — ação que o usuário só exerce sobre a própria conta — e ela precisa entrar em `selfServiceWriteRoutes()` de tests/Feature/Routes/WriteRoutesAuthorizationTest.php, que valida a allowlist nos dois sentidos.

--- a/tests/Feature/Auth/LoginLockoutTest.php
+++ b/tests/Feature/Auth/LoginLockoutTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types = 1);
+
+use App\Models\User;
+use Illuminate\Auth\Events\Lockout;
+use Illuminate\Support\Facades\Event;
+
+/*
+|--------------------------------------------------------------------------
+| Lockout do login
+|--------------------------------------------------------------------------
+|
+| `POST login` é a rota mais atacada da aplicação e a única do grupo `guest`
+| SEM throttle de rota (`routes/auth.php`): `register`, `forgot-password` e
+| `reset-password` carregam `throttle:auth`, o login não. A defesa inteira mora
+| no `LoginRequest::ensureIsNotRateLimited()` — 5 tentativas por `email|ip` —,
+| e até aqui nada exercitava esse limite.
+|
+| O `AuthRouteThrottleTest` chega a documentar a ausência ("O login não entra
+| aqui porque já tem limitação própria via LoginRequest") sem que essa
+| limitação própria fosse provada em lugar nenhum. Este arquivo fecha isso.
+|
+| Cada teste trava uma propriedade que se perde numa refatoração inocente, não
+| só "a 6ª tentativa falha".
+|
+*/
+
+/** Queima as tentativas com senha errada; devolve a última resposta. */
+function tentativasFalhas(string $email, int $vezes = 5)
+{
+    $resposta = null;
+
+    for ($i = 0; $i < $vezes; $i++) {
+        $resposta = test()->post('/login', [
+            'email'    => $email,
+            'password' => 'senha-errada',
+        ]);
+    }
+
+    return $resposta;
+}
+
+it('answers the sixth attempt with the throttle message, not with the failure one', function(): void {
+    $user = User::factory()->create(['is_active' => true]);
+
+    tentativasFalhas($user->email)
+        ->assertSessionHasErrors(['email' => __('auth.failed')]);
+
+    test()->post('/login', ['email' => $user->email, 'password' => 'senha-errada'])
+        ->assertSessionHasErrorsIn('default', ['email']);
+
+    expect(session('errors')->get('email')[0])
+        ->toContain('Tentativas de login em excesso');
+});
+
+it('keeps refusing the correct password while the lockout holds', function(): void {
+    /*
+     * A propriedade que importa para segurança, e a mais fácil de perder ao
+     * mover a checagem para depois do `Auth::attempt()`: o bloqueio não é
+     * contornável acertando a senha na tentativa seguinte.
+     */
+    $user = User::factory()->create(['is_active' => true]);
+
+    tentativasFalhas($user->email);
+
+    $this->post('/login', ['email' => $user->email, 'password' => 'password'])
+        ->assertSessionHasErrors('email');
+
+    $this->assertGuest();
+});
+
+it('locks the pair email+ip, not the ip alone', function(): void {
+    /*
+     * Chave só por IP transformaria a defesa em arma: um atacante trancaria
+     * todo mundo que compartilha a saída NAT, sem saber senha nenhuma.
+     */
+    $vitima   = User::factory()->create(['is_active' => true]);
+    $terceiro = User::factory()->create(['is_active' => true]);
+
+    tentativasFalhas($vitima->email);
+
+    $this->post('/login', ['email' => $terceiro->email, 'password' => 'password'])
+        ->assertRedirect(route('dashboard', absolute: false));
+
+    $this->assertAuthenticatedAs($terceiro);
+});
+
+it('locks the pair email+ip, not the email alone', function(): void {
+    /*
+     * A outra metade da chave. Sem o IP, a mesma conta seria trancável de
+     * qualquer lugar — e força bruta distribuída passaria a derrubar contas
+     * alheias de propósito.
+     */
+    $user = User::factory()->create(['is_active' => true]);
+
+    tentativasFalhas($user->email);
+
+    $this->withServerVariables(['REMOTE_ADDR' => '203.0.113.7'])
+        ->post('/login', ['email' => $user->email, 'password' => 'password'])
+        ->assertRedirect(route('dashboard', absolute: false));
+
+    $this->assertAuthenticatedAs($user);
+});
+
+it('clears the counter after a successful login', function(): void {
+    // Sem o `RateLimiter::clear()`, quem errasse 4 vezes ao longo do dia seria
+    // trancado no primeiro erro seguinte, mesmo tendo entrado no meio.
+    $user = User::factory()->create(['is_active' => true]);
+
+    tentativasFalhas($user->email, 4);
+
+    $this->post('/login', ['email' => $user->email, 'password' => 'password'])
+        ->assertRedirect(route('dashboard', absolute: false));
+
+    $this->post('/logout');
+
+    // Se o contador tivesse sobrevivido, estas 4 já estourariam o limite.
+    tentativasFalhas($user->email, 4);
+
+    expect(session('errors')->get('email')[0])->toBe(__('auth.failed'));
+});
+
+it('fires the Lockout event so a project can alert on it', function(): void {
+    Event::fake([Lockout::class]);
+
+    $user = User::factory()->create(['is_active' => true]);
+
+    tentativasFalhas($user->email, 6);
+
+    Event::assertDispatched(Lockout::class);
+});
+
+it('does not fire the Lockout event before the limit', function(): void {
+    Event::fake([Lockout::class]);
+
+    $user = User::factory()->create(['is_active' => true]);
+
+    tentativasFalhas($user->email, 5);
+
+    Event::assertNotDispatched(Lockout::class);
+});


### PR DESCRIPTION
Fecha #83 · harvest v2, candidato **S4** — origem spinmax @ `e4ec01e`. Único candidato da célula 1 do spinmax que sobreviveu **intacto** às três lentes adversariais.

## O que estava aberto

`POST login` é a única rota do grupo `guest` **sem throttle de rota** (`register`, `forgot-password` e `reset-password` carregam `throttle:auth`). A defesa inteira mora no `LoginRequest::ensureIsNotRateLimited()` — 5 tentativas por `email|ip`.

Nada exercitava esse limite: `grep -rl "Lockout\|tooManyAttempts\|throttleKey\|auth.throttle" tests/` voltava **vazio**, e o `AuthenticationTest` nunca passa de uma tentativa falha.

E é o pior formato de lacuna, porque o `AuthRouteThrottleTest` **documenta a ausência** — *"O login não entra aqui porque já tem limitação própria via LoginRequest (por email+ip)"* — sem que essa limitação própria fosse provada em lugar nenhum. Lê-se como decisão coberta.

## O que entrou

`tests/Feature/Auth/LoginLockoutTest.php`, 7 testes. Nenhum é "a 6ª tentativa falha": cada um trava uma propriedade que uma refatoração inocente derruba.

| Mutação no `LoginRequest` | Resultado |
| ------------------------- | --------- |
| Sem o `ensureIsNotRateLimited()` (não há lockout) | ⨯ 3 falham |
| Checagem **tarde**, só depois do `Auth::attempt()` | ⨯ 3 falham |
| Chave só por **IP** | ⨯ falha |
| Chave só por **e-mail** | ⨯ falha |
| Sem o `RateLimiter::clear()` após sucesso | ⨯ falha |
| Limite frouxo (5 → 50) | ⨯ 3 falham |
| Sem o `event(new Lockout(...))` | ⨯ falha |

As duas metades da chave têm teste próprio porque erram para lados opostos e ambos são reais: **só IP** transforma a defesa em arma (um atacante tranca todo mundo que compartilha a saída NAT, sem saber senha nenhuma); **só e-mail** libera força bruta distribuída e torna possível derrubar conta alheia de propósito.

A mais importante para segurança é a **checagem tarde**: mover `ensureIsNotRateLimited()` para depois do `Auth::attempt()` é o refactor mais natural do mundo e torna o bloqueio contornável acertando a senha na tentativa seguinte.

Uma seção nova em `.ai/rules/routes.md` registra por que o login fica sem `throttle:auth` **de propósito** — o limiter `auth` conta por `$request->ip()`, então acrescentá-lo ali trocaria a chave boa por uma pior. Sem isso, "consertar" a rota é o próximo passo óbvio de quem ler só o arquivo de rotas.

## Nota de método

Duas mutações (chave só por IP, chave só por e-mail) mataram **7 testes cada** na primeira passada — sinal alto demais para o que elas mudam. O `//` do comentário de mutação comia o `);` da chamada e produzia erro de sintaxe: o arquivo inteiro morria, não a propriedade. Refeitas com `/* */`, cada uma mata **exatamente 1**. Fica a regra: mutação com sinal suspeitosamente amplo é mutação a auditar, não evidência a comemorar.

## Gates

`composer ci:check` ✅ 390 testes / 1969 asserções · `corepack pnpm ci:check` ✅ exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
