### PR TITLE
[85]: test(auth): trava o ALCANCE do EnsureUserIsActive, não só o efeito

### DIFF
--- a/.ai/rules/middleware.md
+++ b/.ai/rules/middleware.md
@@ -6,4 +6,7 @@ paths:
 # Middleware
 
 ## Contrato de shared props do Inertia
-Dados globais são compartilhados só em HandleInertiaRequests::share: auth = {user, permissions e roles como arrays de nomes string, impersonating} e flash = {success,error,warning,info} lidos com session()->pull(). Tipe toda prop compartilhada nova em SharedData (resources/js/types/index.d.ts).
+Dados globais são compartilhados só em HandleInertiaRequests::share: name, quote, auth = {user, permissions e roles como arrays de nomes string, impersonating} e ziggy. **Flash não é prop compartilhada** — vai pelo canal nativo do Inertia 3 (`Inertia::flash()`), fora de props, e o share() não o republica; ver .ai/rules/controllers.md e js.md. Tipe toda prop compartilhada nova em SharedData (resources/js/types/index.d.ts), e o shape inteiro está travado por tests/Feature/SharedPropsTest.php.
+
+## Middleware que vale para a app inteira mora no GRUPO, não num arquivo de rota
+`SecurityHeaders`, `SetSensitiveCacheHeaders`, `HandleAppearance`, `HandleInertiaRequests` e `EnsureUserIsActive` entram por `$middleware->web(append: [...])` em bootstrap/app.php. É de propósito: assim cobrem os três arquivos de rota (web, settings, auth) e qualquer arquivo futuro sem ninguém lembrar de nada. Pendurar um deles num `Route::middleware(...)->group()` dentro de routes/web.php — a forma que parece mais explícita — deixa `settings/*` e `auth` descobertos, e é como um projeto derivado permitiu que conta desativada seguisse trocando a própria senha. `tests/Feature/EnsureUserIsActiveTest.php` cobre os três arquivos, uma rota sem `auth` e a presença no grupo.

--- a/tests/Feature/EnsureUserIsActiveTest.php
+++ b/tests/Feature/EnsureUserIsActiveTest.php
@@ -2,7 +2,32 @@
 
 declare(strict_types = 1);
 
+use App\Http\Middleware\EnsureUserIsActive;
 use App\Models\User;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Onde o middleware está pendurado é metade do que ele faz
+|--------------------------------------------------------------------------
+|
+| `EnsureUserIsActive` entra por `$middleware->web(append: [...])` em
+| `bootstrap/app.php`, ou seja, no GRUPO — e por isso cobre os três arquivos de
+| rota (`web.php`, `settings.php`, `auth.php`) e qualquer arquivo futuro, de
+| graça.
+|
+| A forma "natural" de escrever a mesma coisa é pendurá-lo num grupo dentro de
+| `routes/web.php`. Um projeto derivado fez exatamente isso e deixou
+| `settings/*` e as rotas de `auth` descobertas — uma conta desativada seguia
+| trocando a própria senha. Os testes de baixo existiam lá, e continuavam
+| verdes, porque todos exercitavam só o dashboard.
+|
+| Daí os casos abaixo: um por arquivo de rota, um em rota SEM `auth` (o
+| middleware é do grupo, não da autenticação) e um estrutural, que é o único
+| que percebe o dia em que alguém repetir a declaração nos três arquivos e
+| deixar o quarto de fora.
+|
+*/
 
 it('keeps an active user session untouched', function() {
     $user = User::factory()->create(['is_active' => true]);
@@ -35,4 +60,65 @@ it('blocks a deactivated user from logging in at all', function() {
 
     $response->assertSessionHasErrors('email');
     $this->assertGuest();
+});
+
+/** Autentica, desativa a conta no meio da sessão e devolve o usuário. */
+function desativadaNoMeioDaSessao(): User
+{
+    $user = User::factory()->create(['is_active' => true]);
+
+    test()->actingAs($user)->get('/dashboard')->assertOk();
+
+    $user->forceFill(['is_active' => false])->save();
+
+    return $user;
+}
+
+it('ends the session on a settings route, not only on the dashboard', function(): void {
+    // `routes/settings.php`. Era aqui que o derivado deixava a conta desativada
+    // trocar a própria senha e o próprio e-mail.
+    desativadaNoMeioDaSessao();
+
+    $this->get(route('profile.edit'))
+        ->assertRedirect(route('login'))
+        ->assertInertiaFlash('error');
+
+    $this->assertGuest();
+});
+
+it('ends the session on a route from the auth file', function(): void {
+    // `routes/auth.php`. A confirmação de senha é o caminho para as áreas
+    // sensíveis — cobri-la é o mínimo.
+    desativadaNoMeioDaSessao();
+
+    $this->get(route('password.confirm'))
+        ->assertRedirect(route('login'))
+        ->assertInertiaFlash('error');
+
+    $this->assertGuest();
+});
+
+it('ends the session even where no auth middleware runs', function(): void {
+    /*
+     * `/` não carrega `auth`. Se o middleware fosse movido para o grupo
+     * `auth` — a outra forma "natural" de errar —, a sessão de uma conta
+     * desativada sobreviveria em toda rota pública, e ela seguiria vista como
+     * autenticada por qualquer coisa que só leia `$request->user()`.
+     */
+    desativadaNoMeioDaSessao();
+
+    $this->get(route('home'))->assertRedirect(route('login'));
+
+    $this->assertGuest();
+});
+
+it('stays in the web middleware group, so a new route file is covered by default', function(): void {
+    /*
+     * O único caso que percebe a regressão mais teimosa: repetir a declaração
+     * dentro dos três arquivos de rota deixa os três testes acima verdes e
+     * ainda assim quebra a promessa — o próximo `routes/*.php` nasce
+     * descoberto, sem nada avisando.
+     */
+    expect(Route::getMiddlewareGroups()['web'] ?? [])
+        ->toContain(EnsureUserIsActive::class);
 });


### PR DESCRIPTION
Fecha #85 · harvest v2, candidato **S5** — origem spinmax @ `e4ec01e`. Caso raro em que **o boilerplate é o superior**, e o que se colhe do derivado é o guard-rail contra virar ele.

## O que estava aberto

`EnsureUserIsActive` entra por `$middleware->web(append: [...])`, no **grupo** — e é por isso que cobre `routes/web.php`, `routes/settings.php`, `routes/auth.php` e qualquer arquivo futuro, sem ninguém precisar lembrar.

Os três testes que existiam exercitavam **só `/dashboard`**. Mover a declaração para um `Route::middleware(...)->group()` dentro de `routes/web.php` — a forma que *parece* mais explícita — mantinha os três verdes e deixava `settings/*` e `auth` descobertos. É exatamente o que o spinmax faz, e lá uma conta desativada seguia trocando a própria senha e o próprio e-mail.

O teste protegia o **efeito** do middleware e não protegia o **alcance**, que aqui é metade do que ele faz.

## O que entrou

Quatro casos no arquivo existente. **Nenhuma linha de código de app foi tocada** — é guard-rail puro.

| Caso | O que ele sozinho percebe |
| ---- | ------------------------- |
| Rota de `settings.php` (`profile.edit`) | declaração presa a `routes/web.php` |
| Rota de `auth.php` (`password.confirm`) | idem, no outro arquivo |
| Rota **sem `auth`** (`/`) | a outra forma de errar: mover para o grupo `auth`, deixando a sessão da conta desativada sobreviver em toda rota pública |
| Estrutural: presença no grupo `web` | repetir a declaração nos três arquivos e deixar o quarto de fora |

O gradiente das mutações mostra que os quatro puxam coisas diferentes:

| Mutação | Resultado |
| ------- | --------- |
| Fora do grupo `web`, nada no lugar | ⨯ 5 falham |
| Só no grupo autenticado de `routes/web.php` (**a forma do spinmax**) | ⨯ 4 falham |
| Declarado nos **três** arquivos de rota, fora do grupo | ⨯ **exatamente 2** — a rota sem `auth` e o estrutural |

A terceira é a que justifica os dois últimos casos existirem: os três testes "por arquivo" passam nela, e a promessa ("arquivo de rota novo nasce coberto") já se perdeu.

## Correção de fato herdada de outra fatia

`.ai/rules/middleware.md` ainda descrevia `flash` como prop compartilhada lida com `session()->pull()` — contrato que a fatia do flash nativo (PR #68) desfez. `controllers.md` e `js.md` foram atualizados lá; `middleware.md` ficou para trás afirmando algo que o `share()` não faz mais. Corrigido contra o código atual, com a lista real (`name`, `quote`, `auth`, `ziggy`) e ponteiro para o teste que trava o shape.

Fica a nota de método: **fatia que muda um contrato precisa varrer `.ai/rules` inteiro por menções ao contrato antigo**, não só o arquivo que ela editou. Um `grep -rn "flash" .ai/rules/` teria pego isto na hora.

## Gates

`composer ci:check` ✅ 394 testes / 1984 asserções · `corepack pnpm ci:check` ✅ exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
