### PR TITLE
[87]: fix(auth): confirm-password aceitava chute de senha sem limite

### DIFF
--- a/.ai/rules/routes.md
+++ b/.ai/rules/routes.md
@@ -6,7 +6,10 @@ paths:
 # Routes
 
 ## Throttle sempre via limiter nomeado
-Toda rota com rate limit usa limiter nomeado (throttle:auth, throttle:impersonate, throttle:verification) definido em AppServiceProvider::configRateLimiting() — nunca throttle:N,M inline. Caso novo = novo RateLimiter::for() no provider + entrada no teste de contrato AuthRouteThrottleTest.
+Toda rota com rate limit usa limiter nomeado (throttle:auth, throttle:impersonate, throttle:verification, throttle:password-confirmation) definido em AppServiceProvider::configRateLimiting() — nunca throttle:N,M inline. Caso novo = novo RateLimiter::for() no provider + entrada no teste de contrato AuthRouteThrottleTest. Rota atrás de `auth` chaveia o limiter pelo usuário (`$request->user()->id ?? $request->ip()`), não pelo IP: dentro do painel, chavear por IP tranca colegas que compartilham a mesma saída NAT.
+
+## Rota que confere segredo precisa de teto em ALGUM lugar
+O limite pode morar no limiter nomeado da rota ou dentro do próprio FormRequest (é onde vive o do login, por `email|ip`) — mas não pode faltar nos dois. `POST confirm-password` ficou sem nenhum dos dois e aceitava chute ilimitado da senha do PRÓPRIO usuário logado, que é exatamente o segredo que o login protege: sessão sequestrada abria tudo que está atrás de `password.confirm` por força bruta. Ao criar rota que valida senha, token, código ou assinatura, decida onde o teto mora e escreva o teste que prova que ele morde.
 
 ## `POST login` fica sem throttle de rota de propósito
 É a única rota do grupo `guest` sem middleware de limite, e não é esquecimento: o limite dela mora no `LoginRequest` e é por **`email|ip`**, não por IP. Não acrescente `throttle:auth` ali — o limiter `auth` conta só por `$request->ip()`, então ele transformaria a defesa em arma, deixando um atacante trancar todo mundo que compartilha a mesma saída NAT. As quatro propriedades do lockout (senha correta segue recusada durante o bloqueio; as duas metades da chave importam; sucesso zera o contador; o evento `Lockout` dispara) estão travadas em `tests/Feature/Auth/LoginLockoutTest.php` — mexeu no `LoginRequest`, é lá que a conta é prestada.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -106,6 +106,23 @@ class AppServiceProvider extends ServiceProvider
             'verification',
             static fn(Request $request): Limit => Limit::perMinute(6)->by($request->user()->id ?? $request->ip())
         );
+
+        /*
+         * `POST confirm-password` valida a senha do próprio usuário e não tinha
+         * teto nenhum: nem aqui, nem no controller — ao contrário do login, que
+         * carrega o dele no `LoginRequest`. É o MESMO segredo, e a tela existe
+         * justamente porque "estar logado" não basta para o que vem depois
+         * dela; sem limite, quem chega a uma sessão alheia chuta a senha do
+         * dono à vontade até abrir as áreas sensíveis.
+         *
+         * Chave por usuário, como `impersonate` e `verification`: a rota já
+         * exige autenticação, e chavear por IP trancaria colegas atrás do mesmo
+         * NAT para fora dessas áreas.
+         */
+        RateLimiter::for(
+            'password-confirmation',
+            static fn(Request $request): Limit => Limit::perMinute(6)->by($request->user()->id ?? $request->ip())
+        );
     }
 
     private function configCommands(): void

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -54,7 +54,8 @@ Route::middleware('auth')->group(function(): void {
     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
         ->name('password.confirm');
 
-    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
+    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store'])
+        ->middleware('throttle:password-confirmation');
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
         ->name('logout');

--- a/tests/Feature/Auth/AuthRouteThrottleTest.php
+++ b/tests/Feature/Auth/AuthRouteThrottleTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types = 1);
 
+use App\Models\User;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 
@@ -12,8 +13,9 @@ test('the named auth rate limiter is registered', function() {
 it('registers the named limiter', function(string $limiter) {
     expect(RateLimiter::limiter($limiter))->not->toBeNull();
 })->with([
-    'impersonate'  => 'impersonate',
-    'verification' => 'verification',
+    'impersonate'           => 'impersonate',
+    'verification'          => 'verification',
+    'password-confirmation' => 'password-confirmation',
 ]);
 
 // Teste de contrato: garante que ninguém remove o throttle dessas rotas por
@@ -45,6 +47,67 @@ it('keeps the named throttle middleware instead of the inline limit', function(s
     'verification verify' => ['GET', 'verify-email/{id}/{hash}', 'throttle:verification', 'throttle:6,1'],
     'verification send'   => ['POST', 'email/verification-notification', 'throttle:verification', 'throttle:6,1'],
 ]);
+
+// region Re-confirmação de senha
+/*
+ * `POST confirm-password` valida a senha do próprio usuário com
+ * `Auth::guard('web')->validate()` e não tinha limite em lugar nenhum: nem
+ * throttle de rota, nem limiter no controller (ao contrário do `LoginRequest`,
+ * que tem o dele). É o MESMO segredo do login, defendido de um lado só — e a
+ * tela existe justamente porque "estar logado" não basta para o que vem
+ * depois dela. Sem teto, uma sessão sequestrada chutava a senha do dono à
+ * vontade até abrir tudo que está atrás de `password.confirm`.
+ */
+
+test('confirm-password carries the named throttle', function() {
+    $route = collect(Route::getRoutes()->getRoutes())
+        ->first(fn($route): bool => in_array('POST', $route->methods(), true) && $route->uri() === 'confirm-password');
+
+    expect($route)->not->toBeNull()
+        ->and($route->gatherMiddleware())->toContain('throttle:password-confirmation');
+});
+
+test('confirm-password blocks the seventh guess within a minute', function() {
+    $user = User::factory()->create(['is_active' => true]);
+    $this->actingAs($user);
+
+    for ($attempt = 1; $attempt <= 6; $attempt++) {
+        expect($this->post('/confirm-password', ['password' => 'chute-errado'])->status())
+            ->not->toBe(429, "A tentativa {$attempt} não deveria ser bloqueada");
+    }
+
+    $this->post('/confirm-password', ['password' => 'chute-errado'])
+        ->assertStatus(429);
+});
+
+test('the confirm-password limit is per user, not global', function() {
+    // Chave por usuário, como `impersonate` e `verification`. Se fosse global
+    // (ou só por IP), queimar o limite trancaria colegas atrás do mesmo NAT
+    // para fora das áreas sensíveis.
+    $atacado  = User::factory()->create(['is_active' => true]);
+    $terceiro = User::factory()->create(['is_active' => true]);
+
+    $this->actingAs($atacado);
+
+    for ($attempt = 1; $attempt <= 7; $attempt++) {
+        $this->post('/confirm-password', ['password' => 'chute-errado']);
+    }
+
+    $this->actingAs($terceiro)
+        ->post('/confirm-password', ['password' => 'password'])
+        ->assertRedirect();
+});
+
+test('confirm-password still confirms a correct password within the limit', function() {
+    $user = User::factory()->create(['is_active' => true]);
+
+    $this->actingAs($user)
+        ->post('/confirm-password', ['password' => 'password'])
+        ->assertRedirect();
+
+    expect(session()->has('auth.password_confirmed_at'))->toBeTrue();
+});
+// endregion
 
 test('forgot-password blocks the 11th request within a minute', function() {
     for ($attempt = 1; $attempt <= 10; $attempt++) {


### PR DESCRIPTION
Fecha #87 · harvest v2, achado interno **C4** — medido durante a fatia [#84](https://github.com/Simplify-Technology/boilerplate/pull/84) ao mapear quais rotas de auth têm limite. Não veio de projeto-fonte.

## O que estava aberto

`POST confirm-password` aceitava chute de senha **sem limite nenhum**:

- `routes/auth.php` registrava a rota sem middleware de throttle;
- `ConfirmablePasswordController::store()` chama `Auth::guard('web')->validate([...])` direto, sem limiter próprio.

O login carrega o dele dentro do `LoginRequest` (5 por `email|ip`). A re-confirmação, que protege o **mesmo segredo**, não tinha nada em nenhum dos dois lugares.

E a tela existe justamente porque *estar logado não basta* para o que vem depois dela. Sem teto, quem chega a uma sessão alheia — máquina destravada, cookie roubado — chuta a senha do dono à vontade até abrir tudo que está atrás de `password.confirm`: o limite ausente devolve ao atacante exatamente a garantia que a tela deveria cobrar.

Não é o mesmo caso do `POST logout`, que também não tem throttle — lá não há segredo a adivinhar.

## O que entrou

Forma canônica da casa, não inline: `RateLimiter::for('password-confirmation', ...)` no `AppServiceProvider`, 6/min chaveado pelo **usuário** (mesma leitura de `impersonate` e `verification` — a rota já exige autenticação, e chavear por IP trancaria colegas atrás do mesmo NAT para fora das áreas sensíveis), mais `->middleware('throttle:password-confirmation')` na rota.

Cinco testes: dois de contrato (limiter registrado, rota carrega o middleware nomeado) e três comportamentais.

| Mutação | Resultado |
| ------- | --------- |
| Rota sem o throttle (o defeito original) | ⨯ 2 falham |
| Limiter chaveado por **IP** | ⨯ falha |
| Limiter **global**, sem chave | ⨯ falha |
| Limite frouxo (6 → 600) | ⨯ falha |
| `throttle:6,1` inline no lugar do nomeado | ⨯ falha |

O teste "o limite é por usuário, não global" merece nota: ele já passava **antes** do conserto, porque sem limiter nenhum ninguém tranca ninguém. Só depois da correção ele passa a discriminar — e as mutações 2 e 3 são a prova de que hoje ele carrega peso.

## Regra nova

`.ai/rules/routes.md` ganha a generalização, que é o que sobrevive à fatia: **rota que confere segredo precisa de teto em ALGUM lugar** — no limiter nomeado da rota ou dentro do FormRequest, como faz o login —, mas não pode faltar nos dois. E limiter de rota atrás de `auth` chaveia por usuário, não por IP.

## Fora de escopo

- Trocar o `Request` cru do controller por Form Request: o scaffold herdado de `Auth/Settings` é exceção declarada em `.ai/rules/controllers.md`.
- Tratar o 429 na interface — candidato **E5** no BACKLOG, que vale para todos os limiters de uma vez em vez de só para este.

## Gates

`composer ci:check` ✅ 395 testes / 1982 asserções · `corepack pnpm ci:check` ✅ exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
