### PR TITLE
[89]: fix(lgpd): model no contexto de log gravava CPF e notas internas em claro

### DIFF
--- a/.ai/rules/support.md
+++ b/.ai/rules/support.md
@@ -7,3 +7,11 @@ paths:
 
 ## Helpers em app/Support: final, estáticos, puros
 Helpers transversais vivem em app/Support/<Contexto>/ como `final class` com métodos estáticos puros e null-safe (entrada ?string → retorna null para vazio/null). Não crie helpers com estado, singletons ou funções globais; siga o estilo de CpfFormatter/PhoneNormalizer.
+
+## PiiScrubber: o que ele alcança e o que não
+O scrubber tem duas camadas — chave e padrão — e ambas rodam ANTES do formatter do Monolog. Consequências práticas ao logar:
+
+- **Objeto no contexto só é varrido se for `Arrayable`** (model, Collection, resource, DTO que implemente). Qualquer outro objeto atravessa intacto e o formatter o serializa depois que a defesa já passou — foi assim que `['user' => $user]` gravava nome, CPF formatado e notas internas em claro. DTO novo que possa carregar PII implementa `Arrayable`.
+- **`Throwable` em `['exception' => $e]` está fora de alcance**: mensagem e trace são renderizados pelo formatter, e nenhum processor os vê. Medido. Não coloque PII em mensagem de exception.
+- **Chave sensível tem duas listas, e a divisão é deliberada.** `SENSITIVE_KEY_PARTS` casa por substring e só recebe termo inequívoco (`cpf`, `email`, `phone`, `token`, `password`, `address`…), o que cobre a família composta (`user_email`, `billing_address`). `SENSITIVE_KEYS` casa por igualdade e guarda os ambíguos: `name` (senão `role_name`, `permission_name` e `file_name` somem do log, e o RBAC registra os dois primeiros o tempo todo), `rg` (dentro de "o**rg**anization"), `auth` (dentro de "**auth**or"), `cep` (dentro de "ex**cep**tion"), `session`, `mobile`. **Ao acrescentar termo à lista de substring, procure-o dentro de palavras comuns de log antes** — um falso positivo aqui apaga a informação que ia depurar o incidente.
+- Coluna sensível nova no model entra na lista **e** ganha caso no `LogScrubbingTest`; `user_notes` é o precedente.

--- a/app/Support/Logging/PiiScrubber.php
+++ b/app/Support/Logging/PiiScrubber.php
@@ -4,61 +4,104 @@ declare(strict_types = 1);
 
 namespace App\Support\Logging;
 
+use Illuminate\Contracts\Support\Arrayable;
+
 /**
  * Scrubber de PII (LGPD) usado pelo processor Monolog
  * ({@see PiiScrubbingProcessor}) que intercepta o stack de logs padrão.
  *
  * Duas camadas:
- *  - Por chave: qualquer chave de contexto presente em {@see SENSITIVE_KEYS}
- *    (case insensitive) tem o valor substituído por `[REDACTED]` — campos
- *    sensíveis pelo nome, independente do formato do payload
- *    (cpf, cnpj, phone, email, password, token, …).
+ *  - Por chave: chave de contexto que CONTENHA um termo de
+ *    {@see SENSITIVE_KEY_PARTS}, ou que seja exatamente um de
+ *    {@see SENSITIVE_KEYS}, tem o valor substituído por `[REDACTED]` —
+ *    inclusive subárvore inteira.
  *  - Por padrão: strings são varridas por assinaturas de CPF/CNPJ/CEP/
  *    telefone/email/JWT/bearer e substituídas por placeholders.
  *
+ * Objeto que implementa `Arrayable` (model, Collection, DTO, resource) é
+ * convertido antes de descer. Sem isso ele atravessava o processor intacto e
+ * só era serializado pelo formatter do Monolog — DEPOIS das duas camadas —,
+ * então `Log::info('x', ['user' => $user])` gravava nome, CPF formatado e
+ * notas internas em claro, mesmo com o CPF tendo assinatura de regex.
+ *
  * Idempotente: rodar o scrub sobre saída já redigida é um no-op.
+ *
+ * **Limite conhecido, medido:** a mensagem e o trace de um `Throwable` passado
+ * em `['exception' => $e]` são renderizados pelo formatter, fora do alcance de
+ * qualquer processor. A regra continua sendo não colocar PII em mensagem de
+ * exception.
  */
 final class PiiScrubber
 {
     public const REDACTED = '[REDACTED]';
 
-    /** @var list<string> Chaves cujo valor é substituído por inteiro. */
-    private const SENSITIVE_KEYS = [
+    /**
+     * Termos inequívocos: a chave é sensível se os CONTIVER. Cobre a família
+     * composta (`user_email`, `customer_cpf`, `billing_address`), que a
+     * igualdade exata deixava passar sempre que o valor não tinha assinatura
+     * de regex — nome de pessoa e endereço livre não têm.
+     *
+     * Todo termo aqui passou por auditoria de substring acidental. `cep` NÃO
+     * entra: "ex**cep**tion" o contém, e casá-lo apagaria a classe do erro em
+     * todo log de falha.
+     *
+     * @var list<string>
+     */
+    private const SENSITIVE_KEY_PARTS = [
         // Secrets
         'password',
-        'password_confirmation',
         'token',
-        'access_token',
-        'refresh_token',
+        'secret',
         'api_key',
         'api-key',
         'apikey',
-        'secret',
         'authorization',
+        // PII (LGPD)
+        'cpf',
+        'cnpj',
+        'phone',
+        'telefone',
+        'celular',
+        'whatsapp',
+        'email',
+        'e_mail',
+        'address',
+        'endereco',
+    ];
+
+    /**
+     * Termos ambíguos: sensíveis só quando a chave é exatamente isto.
+     *
+     * `name` sozinho é o nome do titular, mas `role_name`, `permission_name` e
+     * `file_name` são dado operacional que o log PRECISA carregar — este
+     * repositório registra os dois primeiros o tempo todo. Pela mesma razão
+     * `rg` (que "o**rg**anization" e "ta**rg**et" contêm), `auth` ("**auth**or"),
+     * `session`, `mobile` e `cep` ficam aqui. Composto de `name` que nomeia
+     * pessoa entra explicitamente na lista, um a um.
+     *
+     * @var list<string>
+     */
+    private const SENSITIVE_KEYS = [
         'auth',
         'bearer',
         'cookie',
         'session',
-        // PII (LGPD)
-        'cpf',
-        'cnpj',
-        'cpf_cnpj',
         'rg',
-        'phone',
-        'telefone',
-        'celular',
         'mobile',
-        'whatsapp',
-        'email',
-        'e_mail',
+        'cep',
         'name',
         'nome',
+        'user_name',
         'full_name',
         'first_name',
         'last_name',
-        'cep',
-        'address',
-        'endereco',
+        // Os quatro campos que o `UserPolicy::viewSensitive()` protege são
+        // `cpf_cnpj`, `phone`, `mobile` e `user_notes`. Os três primeiros já
+        // caem nos termos acima; este faltava, e um model no contexto o
+        // entregava inteiro. `notes` fica exato porque `release_notes` e
+        // `notes_count` são operacionais.
+        'notes',
+        'user_notes',
     ];
 
     /** @var array<string, string> Regex → substituição em strings. */
@@ -85,11 +128,15 @@ final class PiiScrubber
 
     public function scrub(mixed $value): mixed
     {
+        if ($value instanceof Arrayable) {
+            $value = $value->toArray();
+        }
+
         if (is_array($value)) {
             $out = [];
 
             foreach ($value as $key => $sub) {
-                if (is_string($key) && in_array(mb_strtolower($key), self::SENSITIVE_KEYS, true)) {
+                if (is_string($key) && $this->isSensitiveKey($key)) {
                     $out[$key] = self::REDACTED;
 
                     continue;
@@ -106,6 +153,23 @@ final class PiiScrubber
         }
 
         return $value;
+    }
+
+    private function isSensitiveKey(string $key): bool
+    {
+        $key = mb_strtolower($key);
+
+        if (in_array($key, self::SENSITIVE_KEYS, true)) {
+            return true;
+        }
+
+        foreach (self::SENSITIVE_KEY_PARTS as $part) {
+            if (str_contains($key, $part)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function scrubString(string $value): string

--- a/tests/Feature/LogScrubbingTest.php
+++ b/tests/Feature/LogScrubbingTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types = 1);
 
+use App\Models\User;
 use App\Support\Logging\PiiAwareTap;
 use App\Support\Logging\PiiScrubber;
 use Illuminate\Support\Facades\Log;
@@ -57,3 +58,115 @@ it('scrubs pii out of what actually reaches the log file', function() {
 it('keeps the shipped channels wired to the scrubber', function(string $channel) {
     expect(config("logging.channels.{$channel}.tap"))->toContain(PiiAwareTap::class);
 })->with(['single', 'daily', 'stack']);
+
+// region Objeto no contexto
+/*
+ * `scrub()` tratava `array` e `string` e devolvia qualquer outra coisa intacta.
+ * O objeto atravessava o processor sem ser tocado e só então o formatter do
+ * Monolog o serializava — depois que a única defesa já tinha passado. As duas
+ * camadas (chave e padrão) ficavam ATRÁS do formatter, e por isso vazava até o
+ * CPF formatado, que a camada de padrão pegaria numa string comum.
+ */
+
+it('scrubs a model handed to the log context', function() {
+    $user = User::factory()->create([
+        'cpf_cnpj'   => '529.982.247-25',
+        'phone'      => '(11) 98765-4321',
+        'name'       => 'Fulana de Tal',
+        'user_notes' => 'anotação interna do RH',
+    ]);
+
+    Log::channel('testing_scrub')->info('perfil atualizado', ['user' => $user]);
+
+    $written = file_get_contents($this->logPath);
+
+    expect($written)
+        ->not->toContain('529.982.247-25')
+        ->not->toContain('(11) 98765-4321')
+        ->not->toContain('Fulana de Tal')
+        ->not->toContain('anotação interna do RH')
+        // O id continua no log: é o que serve para depurar.
+        ->toContain((string) $user->id);
+});
+
+it('scrubs a collection handed to the log context', function() {
+    Log::channel('testing_scrub')->info('lote', [
+        'dados' => collect(['cpf' => '529.982.247-25', 'pedido' => 'abc-123']),
+    ]);
+
+    $written = file_get_contents($this->logPath);
+
+    expect($written)
+        ->not->toContain('529.982.247-25')
+        ->toContain('abc-123');
+});
+
+// endregion
+// region Chave composta
+
+it('redacts a composite key whose value no pattern would catch', function() {
+    /*
+     * O caso que só a camada de CHAVE resolve: nome de pessoa e endereço livre
+     * não têm assinatura de regex. Com igualdade exata, `user_name` e
+     * `billing_address` passavam inteiros.
+     */
+    Log::channel('testing_scrub')->info('cadastro', [
+        'user_name'       => 'Fulana de Tal',
+        'billing_address' => 'Praça da Sé, 100, apto 42',
+    ]);
+
+    $written = file_get_contents($this->logPath);
+
+    expect($written)
+        ->not->toContain('Fulana de Tal')
+        ->not->toContain('Praça da Sé');
+});
+
+it('keeps operational keys that merely contain an ambiguous word', function() {
+    /*
+     * O outro lado, e o motivo de a lista ser dividida em duas: casar `name`,
+     * `rg`, `auth` ou `session` por substring apagaria metade do log útil deste
+     * repositório — o RBAC registra `role_name` e `permission_name` o tempo
+     * todo, e `organization` contém `rg`.
+     */
+    Log::channel('testing_scrub')->info('operação', [
+        'role_name'       => 'manager',
+        'permission_name' => 'manage_users',
+        'file_name'       => 'relatorio.pdf',
+        'organization'    => 'acme',
+        'author'          => 'sistema',
+        'session_count'   => 3,
+        // `exception` CONTÉM "cep" — casar `cep` por substring apagaria a
+        // classe do erro em todo log de falha. Achado da auditoria de termos,
+        // e o motivo de `cep` ficar na lista exata.
+        'exception' => 'InvalidArgumentException',
+    ]);
+
+    $written = file_get_contents($this->logPath);
+
+    expect($written)
+        ->toContain('manager')
+        ->toContain('manage_users')
+        ->toContain('relatorio.pdf')
+        ->toContain('acme')
+        ->toContain('sistema')
+        ->toContain('InvalidArgumentException');
+});
+
+it('still redacts the exact ambiguous keys', function() {
+    // `name` sozinho é o nome do titular; `session` sozinho é o identificador.
+    Log::channel('testing_scrub')->info('titular', [
+        'name'    => 'Fulana de Tal',
+        'session' => 'abcdef123456',
+        'auth'    => 'algum-segredo',
+    ]);
+
+    $written = file_get_contents($this->logPath);
+
+    expect($written)
+        ->not->toContain('Fulana de Tal')
+        ->not->toContain('abcdef123456')
+        ->not->toContain('algum-segredo');
+});
+
+// endregion


### PR DESCRIPTION
Fecha #89 · harvest v2, candidato **S3** — origem `spinmax app/app/Support/PiiScrubber.php@e4ec01e`.

## O que estava aberto

Medido de primeira mão, com o mesmo canal que o `LogScrubbingTest` usa (tap real, arquivo real):

| O que foi logado | O que chegou ao arquivo |
| ---------------- | ----------------------- |
| `['user' => $user]` | `name`, `cpf_cnpj` **formatado** e `user_notes` **em claro** |
| `['dados' => collect(['cpf' => '…'])]` | CPF **em claro** |
| `['user_email' => …, 'billing_address' => …]` | dependia só da camada de padrão — que não alcança nome nem endereço livre |

**Por que o model vazava até o CPF formatado**, que a camada de padrão pegaria numa string comum: `scrub()` tratava `array` e `string` e devolvia qualquer outra coisa intacta. O objeto atravessava o processor sem ser tocado e só então o formatter do Monolog o serializava — **depois** que a única defesa já tinha passado. As duas camadas ficavam atrás do formatter.

**Por que chave composta escapava:** `in_array(mb_strtolower($key), SENSITIVE_KEYS, true)` é igualdade exata. `user_email` e `billing_address` não estão na lista, então dependiam inteiramente de o VALOR casar um regex. Vale para e-mail e CPF formatado; não vale para nome de pessoa nem endereço livre.

## O que entrou

1. **Ramo `Arrayable` no `scrub()`** — fecha o vazamento para model, Collection, resource e DTO que implemente.
2. **Lista de chaves partida em duas**: `SENSITIVE_KEY_PARTS` casa por substring e só recebe termo inequívoco (`cpf`, `email`, `phone`, `token`, `password`, `address`…); `SENSITIVE_KEYS` casa por igualdade e guarda os ambíguos.
3. `user_notes` entrou na lista — é um dos quatro campos que o `UserPolicy::viewSensitive()` protege (fatia [#80](https://github.com/Simplify-Technology/boilerplate/pull/80)) e o único que nenhum termo alcançava.

### A divisão em duas listas não é estética

Casar por substring os termos ambíguos apagaria o log útil:

- **`name`** → `role_name`, `permission_name`, `file_name`. Este repositório registra os dois primeiros o tempo todo.
- **`rg`** → dentro de "o**rg**anization", "ta**rg**et".
- **`auth`** → dentro de "**auth**or".
- **`cep`** → dentro de "ex**cep**tion". Este é o mais grave: promover `cep` a substring **apaga a classe do erro em todo log de falha**. Foi achado na auditoria de termos, antes de escrever a lista, e virou teste.

## Testes

5 casos novos em `tests/Feature/LogScrubbingTest.php` — dois provando o conserto, três guardando o que **não** pode ser redigido.

| Mutação | Resultado |
| ------- | --------- |
| Sem o ramo `Arrayable` (o vazamento original) | ⨯ 2 falham |
| Volta à igualdade exata de chave | ⨯ falha |
| **Tudo** por substring, inclusive os ambíguos | ⨯ falha |
| `cep` promovido a substring (come `exception`) | ⨯ falha |
| Sem `user_notes`/`notes` na lista | ⨯ falha |

## O que NÃO foi absorvido da origem

- Os termos de domínio do spinmax (`customer`, `payer`, `holder`, `recipient`): apagariam `customer_id` num boilerplate genérico, e a lente já tinha marcado "não generaliza".
- A fiação (tap/processor), classificada como `[atual]` — segue como está.

## Limite documentado, não consertado

Mensagem e trace de `Throwable` passado em `['exception' => $e]` são renderizados pelo formatter, fora do alcance de qualquer processor. **Medido: vaza.** A regra continua sendo não colocar PII em mensagem de exception — está na docblock e em `.ai/rules/support.md`, junto com a instrução de procurar todo termo novo de substring dentro de palavras comuns de log antes de adicioná-lo.

## Gates

`composer ci:check` ✅ 416 testes / 2046 asserções · `corepack pnpm ci:check` ✅ exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
