### PR TITLE
[91]: fix(a11y): o erro do formulário chegava mudo ao leitor de tela

### DIFF
--- a/.ai/rules/js.md
+++ b/.ai/rules/js.md
@@ -25,3 +25,9 @@ Iniciar e encerrar impersonation passa por startImpersonation/stopImpersonation 
 
 ## Textos de UI em português hardcoded
 O frontend é monolíngue pt_BR: escreva textos de UI (páginas React, labels, mensagens) diretamente em português, sem biblioteca de i18n nem chaves JSON.
+
+## Erro de campo é anunciado por role="alert", nunca por aria-live
+Mensagem de erro de formulário só existe DEPOIS da falha, e `aria-live` num nó recém-montado não anuncia — a região precisa preexistir à mudança. Use `InputError` (que já traz `role="alert"`, `data-slot="input-error"` e guarda de string em branco) e não reescreva o `<p>` na tela. Não troque o `role="alert"` por `aria-live` "para ficar menos intrusivo": isso devolve o silêncio. Região polite persistente de nível de formulário é uma evolução separada — ela precisa preexistir de verdade, com slot sempre renderizado, e tem consequências de layout (o gap do `flex-col`) e de `aria-describedby` a decidir antes.
+
+## Wrapper de primitivo FUNDE o ARIA que vem em props, não redeclara
+Componente que faz `{...props}` e depois escreve `aria-*` próprio sempre ganha do que veio de fora — foi assim que o `DateInput` apagava o `aria-invalid` que o `FormField` injeta por `cloneElement`. Mover a declaração para antes do spread NÃO resolve e cria o bug espelhado: o `cloneElement` grava `'aria-invalid': undefined` como chave própria quando não há erro, e esse `undefined` apaga o valor do wrapper. A única forma correta é a fusão, com o de fora tendo precedência e o próprio como fallback: `aria-invalid={props['aria-invalid'] ?? invalid ?? undefined}`. Vale para todo `aria-*` e para `role` em wrapper de primitivo.

--- a/resources/js/components/input-error.tsx
+++ b/resources/js/components/input-error.tsx
@@ -1,9 +1,21 @@
 import { cn } from '@/lib/utils';
 import { type HTMLAttributes } from 'react';
 
+/**
+ * Mensagem de erro de um campo.
+ *
+ * `role="alert"` não é decoração: o nó só existe DEPOIS da falha, e
+ * `aria-live` num nó recém-montado não anuncia nada — a região precisa
+ * preexistir à mudança. Para conteúdo inserido dinamicamente, `role="alert"` é
+ * o mecanismo. Sem ele, o campo ganhava `aria-invalid` e o motivo nunca era
+ * falado, em 28 usos.
+ *
+ * Mensagem em branco não renderiza: um `role="alert"` vazio anuncia o silêncio
+ * e deixa o campo apontando `aria-describedby` para lugar nenhum.
+ */
 export default function InputError({ message, className = '', ...props }: HTMLAttributes<HTMLParagraphElement> & { message?: string }) {
-    return message ? (
-        <p {...props} className={cn('text-sm text-red-600 dark:text-red-400', className)}>
+    return message?.trim() ? (
+        <p {...props} role="alert" data-slot="input-error" className={cn('text-sm text-red-600 dark:text-red-400', className)}>
             {message}
         </p>
     ) : null;

--- a/resources/js/components/ui/date-input.tsx
+++ b/resources/js/components/ui/date-input.tsx
@@ -45,7 +45,15 @@ export function DateInput({ value, onChange, min, max, invalid, clearable = fals
                 value={value ?? ''}
                 min={min}
                 max={max}
-                aria-invalid={invalid || undefined}
+                // FUSÃO, não redeclaração. O `FormField` injeta `aria-invalid`
+                // por `cloneElement`, e este atributo vinha DEPOIS do
+                // `{...props}` — o próprio ganhava sempre, e o campo dentro de
+                // um formulário com erro ficava válido para o leitor de tela.
+                // Mover a linha para antes do spread reintroduz o bug
+                // espelhado: o `cloneElement` grava `'aria-invalid': undefined`
+                // como chave PRÓPRIA quando não há erro, e esse `undefined`
+                // apagaria o `invalid` daqui.
+                aria-invalid={props['aria-invalid'] ?? invalid ?? undefined}
                 onChange={(event) => onChange(event.target.value || null)}
                 className={cn(
                     // O ícone de calendário do WebKit é ESTILIZADO, não escondido:

--- a/resources/js/test/components/input-error.test.tsx
+++ b/resources/js/test/components/input-error.test.tsx
@@ -1,0 +1,61 @@
+import InputError from '@/components/input-error';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+/*
+ * O erro de formulário chegava mudo ao leitor de tela: `<p>` sem `role` nem
+ * `aria-live`, em 28 usos. O campo ganhava `aria-invalid` e o MOTIVO nunca era
+ * falado.
+ *
+ * O remédio do projeto de origem — `aria-live="polite"` no próprio nó — não
+ * funciona: `aria-live` só anuncia mudança dentro de uma região que JÁ existia.
+ * Um nó recém-montado não é anunciado. Para conteúdo inserido dinamicamente, o
+ * mecanismo é `role="alert"`.
+ */
+describe('InputError', () => {
+    it('announces the message through role="alert"', () => {
+        render(<InputError message="A senha informada está incorreta." />);
+
+        const alerta = screen.getByRole('alert');
+
+        expect(alerta).toHaveTextContent('A senha informada está incorreta.');
+    });
+
+    it('renders nothing without a message', () => {
+        const { container } = render(<InputError />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing for a blank message', () => {
+        // Um `role="alert"` vazio é pior que nenhum: o leitor anuncia o silêncio
+        // e o campo ganha um nó descrito sem descrição.
+        const { container } = render(<InputError message="   " />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('carries the slot marker and keeps forwarded props', () => {
+        render(<InputError id="campo-erro" message="Campo obrigatório." />);
+
+        const alerta = screen.getByRole('alert');
+
+        expect(alerta).toHaveAttribute('id', 'campo-erro');
+        expect(alerta).toHaveAttribute('data-slot', 'input-error');
+    });
+
+    it('is the node that aria-describedby points at inside a FormField', async () => {
+        const { FormField } = await import('@/components/ui/form-field');
+
+        render(
+            <FormField label="E-mail" htmlFor="email" error="Informe um e-mail válido.">
+                <input id="email" />
+            </FormField>,
+        );
+
+        const alerta = screen.getByRole('alert');
+        const campo = screen.getByLabelText('E-mail');
+
+        expect(campo.getAttribute('aria-describedby')).toContain(alerta.id);
+    });
+});

--- a/resources/js/test/components/ui/date-input.test.tsx
+++ b/resources/js/test/components/ui/date-input.test.tsx
@@ -60,4 +60,34 @@ describe('DateInput', () => {
 
         expect(screen.getByLabelText('Data')).toHaveAttribute('aria-invalid', 'true');
     });
+
+    /*
+     * O `FormField` injeta `aria-invalid` no filho por `cloneElement`, e o
+     * `DateInput` redeclarava o atributo DEPOIS do `{...props}` — o próprio
+     * ganhava sempre, e o campo dentro de um formulário com erro ficava válido
+     * aos olhos do leitor de tela.
+     *
+     * A correção óbvia (mover a linha para antes do spread) reintroduz o bug
+     * espelhado: o `cloneElement` grava `'aria-invalid': undefined` como chave
+     * PRÓPRIA quando não há erro, e esse `undefined` apagaria o `invalid` do
+     * próprio componente. Só a fusão atende aos dois casos, e é por isso que
+     * existem os dois testes abaixo.
+     */
+    it('honours an aria-invalid coming from a parent wrapper', () => {
+        render(<DateInput aria-label="Data" value={null} onChange={vi.fn()} aria-invalid />);
+
+        expect(screen.getByLabelText('Data')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('keeps its own invalid when the parent passes aria-invalid undefined', () => {
+        render(<DateInput aria-label="Data" value={null} onChange={vi.fn()} invalid aria-invalid={undefined} />);
+
+        expect(screen.getByLabelText('Data')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('stays valid when neither side marks it', () => {
+        render(<DateInput aria-label="Data" value={null} onChange={vi.fn()} />);
+
+        expect(screen.getByLabelText('Data')).not.toHaveAttribute('aria-invalid');
+    });
 });


### PR DESCRIPTION
Fecha #91 · harvest v2, candidatos **E6 + E20** — origem ctfinance @ `b8c6d57`.

## E6 — a mensagem de erro chegava muda ao leitor de tela

`InputError` renderizava um `<p>` sem `role` nem `aria-live`. São **28 usos em 10 arquivos**: login, cadastro, troca de senha, confirmação de senha, exclusão de conta, formulário de usuário. O campo ganhava `aria-invalid` e o **motivo** nunca era falado.

**O remédio da origem foi rejeitado de propósito.** O ctfinance põe `aria-live="polite"` no próprio nó — e `aria-live` num nó recém-montado **não anuncia nada**: a região precisa preexistir à mudança. Para conteúdo inserido dinamicamente o mecanismo é `role="alert"`. É a diferença entre parecer corrigido e estar corrigido, e tem mutação provando cada lado.

Entram também `data-slot="input-error"` e guarda de string em branco — um `role="alert"` vazio anuncia o silêncio e deixa o `aria-describedby` do campo apontando para nada.

## E20 — `DateInput` apagava o `aria-invalid` que o `FormField` injeta

`{...props}` seguido de `aria-invalid={invalid || undefined}`: o atributo próprio ganhava sempre.

**A correção óbvia está errada.** Mover a linha para antes do spread reintroduz o bug espelhado, porque o `cloneElement` do `FormField` grava `'aria-invalid': undefined` como **chave própria** quando não há erro — e esse `undefined` apagaria o `invalid` do próprio componente. Só a fusão atende aos dois casos:

```tsx
aria-invalid={props['aria-invalid'] ?? invalid ?? undefined}
```

Alcance hoje: os 2 usos (`date-range-filter.tsx:87,96`) não passam por `FormField`, então **nada muda em tela** — é trava para quando o campo de data entrar num formulário. Registrado assim para não vender conserto visível que não houve.

## Testes

9 casos novos (Vitest + Testing Library), 5 mutações:

| Mutação | Resultado |
| ------- | --------- |
| Sem `role="alert"` (o defeito original) | ⨯ 3 falham |
| `aria-live="polite"` no lugar (**o remédio do ctfinance**) | ⨯ 3 falham |
| Sem a guarda de string em branco | ⨯ falha |
| `DateInput` redeclara depois do spread (o defeito original) | ⨯ falha |
| `DateInput` só move para antes do spread (**a correção errada**) | ⨯ falha |

As duas linhas em negrito são o valor da fatia: as duas alternativas que um revisor razoável proporia estão cobertas por teste, cada uma pelo caso que a derruba.

## Fora de escopo, com motivo

- **A troca de className para `text-destructive`** (metade visual da dimensão 6): `--destructive` no escuro dá **3.99:1** como texto. Enquanto o F3 não entrar — represado até as células 6 do cuidari e do ctvitrine —, a troca **regride** acessibilidade. O `text-red-600 dark:text-red-400` fica.
- **Região polite persistente de nível de formulário.** É a evolução natural (com 4 erros de um 422, 4 `role="alert"` disparam em série), mas tem dois obstáculos que merecem decisão própria: um slot sempre renderizado adiciona o gap do `flex-col gap-2` embaixo de todo campo, e tornar o `errorId` estável faz `aria-describedby` existir sempre — contrariando um teste verde hoje. Registrado em `.ai/rules/js.md`.

## Gates

`corepack pnpm ci:check` ✅ 31 arquivos / 212 testes · `composer ci:check` ✅ exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
