### PR TITLE
[93]: fix(ux): o estado vazio emitia HTML inválido e não dava saída

### DIFF
--- a/.ai/rules/js.md
+++ b/.ai/rules/js.md
@@ -25,3 +25,9 @@ Iniciar e encerrar impersonation passa por startImpersonation/stopImpersonation 
 
 ## Textos de UI em português hardcoded
 O frontend é monolíngue pt_BR: escreva textos de UI (páginas React, labels, mensagens) diretamente em português, sem biblioteca de i18n nem chaves JSON.
+
+## Vazio-por-filtro e vazio-inicial são estados diferentes, com saídas diferentes
+Listagem vazia porque o filtro não casou nada pede "limpar filtros"; listagem vazia porque não há registro nenhum pede o CTA de criar o primeiro. Use `EmptyState` com a prop `action` e escolha a saída pela condição — não basta trocar o TEXTO e deixar a pessoa sem caminho, que era o caso de `pages/users/index.tsx` ("Limpe os filtros ou tente outro termo" sem botão de limpar, com o `clearFilters` do `use-user-filters` já disponível na mesma tela). Todo estado vazio de listagem sai com uma ação.
+
+## EmptyState não emite linha de tabela
+`EmptyState` renderiza só o conteúdo; quem abre `<Table.Row>`/`<Table.Cell>` é o call-site. O componente já teve um ramo `type="row"` que montava a linha por dentro enquanto o call-site também montava — e o DOM recebia `<tr>` dentro de `<div>` dentro de `<td>`. Ao usar em tabela, abra a célula na tabela e ponha o `EmptyState` dentro dela, sem embrulho extra.

--- a/resources/js/components/empty-state.tsx
+++ b/resources/js/components/empty-state.tsx
@@ -1,44 +1,48 @@
 import { Icon } from '@/components/ui/icon';
-import { Box, Flex, Table, Text } from '@radix-ui/themes';
+import { cn } from '@/lib/utils';
 import { FileQuestion, LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
 
 interface EmptyStateProps {
     title: string;
     description?: string;
     icon?: LucideIcon;
-    type?: 'row' | 'default';
+    /**
+     * A saída do vazio. Vazio-por-filtro e vazio-inicial são estados
+     * diferentes e pedem ações diferentes: limpar o filtro num, criar o
+     * primeiro registro no outro. Sem isto, a tela diz o que aconteceu e não
+     * dá caminho — inclusive quando o próprio texto promete um ("Limpe os
+     * filtros", sem botão de limpar).
+     */
+    action?: ReactNode;
+    className?: string;
 }
 
-export function EmptyState({ title, description, icon = FileQuestion, type = 'default' }: EmptyStateProps) {
-    if (type === 'row') {
-        return (
-            <Table.Row>
-                <Table.Cell colSpan={100}>
-                    <Flex align="center" justify="center" py="6" direction="column" gap="2">
-                        <Icon iconNode={icon} className="text-muted-foreground" />
-                        <Text weight="medium">{title}</Text>
-                        {description && (
-                            <Text size="2" color="gray">
-                                {description}
-                            </Text>
-                        )}
-                    </Flex>
-                </Table.Cell>
-            </Table.Row>
-        );
-    }
-
+/**
+ * Estado vazio de listagem.
+ *
+ * Não emite linha de tabela: o ramo `type="row"` que existia aqui montava
+ * `Table.Row`/`Table.Cell` PRÓPRIOS, e o único call-site já embrulhava o
+ * componente — o que chegava ao DOM era `<tr>` dentro de `<div>` dentro de
+ * `<td>`. Quem posiciona a célula é a tabela; este componente é só o conteúdo.
+ */
+export function EmptyState({ title, description, icon = FileQuestion, action, className }: EmptyStateProps) {
     return (
-        <Box>
-            <Flex align="center" justify="center" py="8" direction="column" gap="2">
-                <Icon iconNode={icon} className="text-muted-foreground" />
-                <Text weight="medium">{title}</Text>
-                {description && (
-                    <Text size="2" color="gray">
-                        {description}
-                    </Text>
-                )}
-            </Flex>
-        </Box>
+        <div
+            data-slot="empty-state"
+            data-testid="empty-state"
+            className={cn('flex flex-col items-center justify-center gap-3 py-8 text-center', className)}
+        >
+            <span aria-hidden="true" className="bg-muted text-muted-foreground flex size-12 shrink-0 items-center justify-center rounded-full">
+                <Icon iconNode={icon} className="size-6" />
+            </span>
+
+            <div className="flex flex-col gap-1">
+                <h3 className="text-foreground text-base font-medium">{title}</h3>
+                {description ? <p className="text-muted-foreground max-w-prose text-sm">{description}</p> : null}
+            </div>
+
+            {action ? <div className="mt-1 flex flex-wrap items-center justify-center gap-2">{action}</div> : null}
+        </div>
     );
 }

--- a/resources/js/components/permissions/role-users-table.tsx
+++ b/resources/js/components/permissions/role-users-table.tsx
@@ -5,6 +5,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSepara
 import { cn } from '@/lib/utils';
 import type { RoleUsersTableProps } from '@/types/permissions';
 import { getUserInitials } from '@/utils/users/user-helpers';
+import { Link } from '@inertiajs/react';
 import { Table } from '@radix-ui/themes';
 import { Ellipsis, Mail, Settings, UserPlus, Users, UserX } from 'lucide-react';
 import { useState } from 'react';
@@ -133,14 +134,16 @@ export function RoleUsersTable({ users, roleLabel, assignableRoles = [], onRevok
                             ) : (
                                 <Table.Row>
                                     <Table.Cell colSpan={3}>
-                                        <div className="flex items-center justify-center py-12">
-                                            <EmptyState
-                                                title="Nenhum usuário encontrado"
-                                                description={`Ninguém está no cargo de ${roleLabel} ainda. Atribua o cargo pela tela de usuários.`}
-                                                icon={UserX}
-                                                type="row"
-                                            />
-                                        </div>
+                                        <EmptyState
+                                            title="Nenhum usuário encontrado"
+                                            description={`Ninguém está no cargo de ${roleLabel} ainda. O cargo se atribui na tela de usuários.`}
+                                            icon={UserX}
+                                            action={
+                                                <Button variant="outline" size="sm" asChild>
+                                                    <Link href={route('users.index')}>Ir para usuários</Link>
+                                                </Button>
+                                            }
+                                        />
                                     </Table.Cell>
                                 </Table.Row>
                             )}

--- a/resources/js/pages/users/index.tsx
+++ b/resources/js/pages/users/index.tsx
@@ -47,6 +47,11 @@ export default function Index({ users, roles, assignableRoles = [], filters = {}
 
     const { canDeleteUser, canEdit, canImpersonate, canManagePermissions, canAssignRoles } = useUserPermissions();
 
+    // A condição existia duplicada em título e descrição do estado vazio; ela é
+    // uma pergunta só ("a lista está vazia POR FILTRO?") e decide qual saída
+    // oferecer.
+    const hasActiveFilters = Boolean(filters.search) || filters.role_id !== undefined || filters.is_active !== undefined;
+
     // Pré-calcular flags de permissão uma vez (otimização para evitar chamadas repetidas no map)
     const hasManagePermissions = useMemo(() => canManagePermissions(), [canManagePermissions]);
     const hasAssignRoles = useMemo(() => canAssignRoles(), [canAssignRoles]);
@@ -269,19 +274,37 @@ export default function Index({ users, roles, assignableRoles = [], filters = {}
                                 ) : (
                                     <Table.Row>
                                         <Table.Cell colSpan={6}>
-                                            <EmptyState
-                                                title={
-                                                    filters.search || filters.role_id !== undefined || filters.is_active !== undefined
-                                                        ? 'Nenhum usuário bate com esses filtros'
-                                                        : 'Nenhum usuário cadastrado ainda'
-                                                }
-                                                description={
-                                                    filters.search || filters.role_id !== undefined || filters.is_active !== undefined
-                                                        ? 'Limpe os filtros ou tente outro termo de busca'
-                                                        : 'Clique em "Novo Usuário" para cadastrar o primeiro'
-                                                }
-                                                icon={User2}
-                                            />
+                                            {/*
+                                             * Vazio-por-filtro e vazio-inicial são estados diferentes e
+                                             * pedem saídas diferentes. O texto já distinguia os dois; o
+                                             * que faltava era a ação que ele promete.
+                                             */}
+                                            {hasActiveFilters ? (
+                                                <EmptyState
+                                                    title="Nenhum usuário bate com esses filtros"
+                                                    description="Tente outro termo de busca ou volte à lista completa."
+                                                    icon={User2}
+                                                    action={
+                                                        <Button variant="outline" size="sm" onClick={clearFilters}>
+                                                            Limpar filtros
+                                                        </Button>
+                                                    }
+                                                />
+                                            ) : (
+                                                <EmptyState
+                                                    title="Nenhum usuário cadastrado ainda"
+                                                    description="Cadastre a primeira pessoa para começar a montar a equipe."
+                                                    icon={User2}
+                                                    action={
+                                                        <Button size="sm" asChild>
+                                                            <Link href={route('users.create')}>
+                                                                <Plus className="h-4 w-4" />
+                                                                Novo Usuário
+                                                            </Link>
+                                                        </Button>
+                                                    }
+                                                />
+                                            )}
                                         </Table.Cell>
                                     </Table.Row>
                                 )}

--- a/resources/js/test/components/empty-state.test.tsx
+++ b/resources/js/test/components/empty-state.test.tsx
@@ -1,0 +1,64 @@
+import { EmptyState } from '@/components/empty-state';
+import { render, screen } from '@testing-library/react';
+import { UserX } from 'lucide-react';
+import { describe, expect, it } from 'vitest';
+
+/*
+ * Dois defeitos moravam aqui.
+ *
+ * 1. O ramo `type="row"` montava `Table.Row`/`Table.Cell` PRÓPRIOS, e o único
+ *    call-site já embrulhava o componente numa célula — o DOM recebia `<tr>`
+ *    dentro de `<div>` dentro de `<td>`. Quem posiciona a célula é a tabela.
+ * 2. O vazio não tinha saída: a tela dizia "Limpe os filtros" sem oferecer o
+ *    botão de limpar, e "atribua o cargo pela tela de usuários" sem link.
+ */
+describe('EmptyState', () => {
+    it('announces the title as a heading', () => {
+        render(<EmptyState title="Nenhum usuário cadastrado ainda" />);
+
+        expect(screen.getByRole('heading', { name: 'Nenhum usuário cadastrado ainda' })).toBeInTheDocument();
+    });
+
+    it('renders the description when given', () => {
+        render(<EmptyState title="Vazio" description="Cadastre a primeira pessoa." />);
+
+        expect(screen.getByText('Cadastre a primeira pessoa.')).toBeInTheDocument();
+    });
+
+    it('renders the action so the empty state is not a dead end', () => {
+        render(<EmptyState title="Vazio" action={<button type="button">Limpar filtros</button>} />);
+
+        expect(screen.getByRole('button', { name: 'Limpar filtros' })).toBeInTheDocument();
+    });
+
+    it('works without an action', () => {
+        render(<EmptyState title="Vazio" />);
+
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('hides the decorative icon from assistive tech', () => {
+        const { container } = render(<EmptyState title="Vazio" icon={UserX} />);
+
+        expect(container.querySelector('[aria-hidden="true"] svg')).not.toBeNull();
+    });
+
+    it('never emits table markup of its own', () => {
+        /*
+         * A regressão que este teste existe para pegar: um `<tr>` ou `<td>`
+         * saindo daqui só é válido se a tabela inteira vier junto, e o
+         * componente é usado DENTRO de uma célula que o call-site já abriu.
+         */
+        const { container } = render(<EmptyState title="Vazio" description="Sem nada" />);
+
+        expect(container.querySelector('tr')).toBeNull();
+        expect(container.querySelector('td')).toBeNull();
+        expect(container.querySelector('table')).toBeNull();
+    });
+
+    it('carries the slot marker for the call sites', () => {
+        render(<EmptyState title="Vazio" />);
+
+        expect(screen.getByTestId('empty-state')).toHaveAttribute('data-slot', 'empty-state');
+    });
+});


### PR DESCRIPTION
Fecha #93 · harvest v2, candidatos **E14 + E15** (dimensão 5) mais a metade visual pareada pela dimensão 6. Origem: ctfinance @ `b8c6d57`.

## E14 — HTML inválido vivo

`empty-state.tsx` tinha um ramo `type="row"` que montava `Table.Row`/`Table.Cell` **próprios** — e o único call-site (`permissions/role-users-table.tsx`) já embrulhava o componente numa célula. O que chegava ao DOM:

```html
<td><div><tr>…</tr></div></td>
```

O ramo sai, e com ele a prop `type`, que ficava órfã. Quem posiciona a célula é a tabela; o componente é só o conteúdo.

## E15 — o vazio era beco sem saída

A listagem de usuários já distinguia vazio-por-filtro de vazio-inicial **no texto** — *"Limpe os filtros ou tente outro termo de busca"* — e não oferecia:

- nem o botão de limpar, sendo que `clearFilters` vem do `use-user-filters` e **já é usado na mesma tela**;
- nem o CTA de cadastrar no vazio-inicial, sendo que o botão "Novo Usuário" existe no cabeçalho logo acima.

E `role-users-table.tsx` mandava *"atribua o cargo pela tela de usuários"* sem link para ela.

`EmptyState` passa a aceitar `action`, e os dois estados saem com a ação que o próprio texto promete. A condição duplicada entre título e descrição virou uma variável só (`hasActiveFilters`), preservando a semântica original — `search: ''` continua **não** contando como filtro ativo.

## Metade visual (dimensão 6)

Corpo em `@radix-ui/themes` (`Box`/`Flex`/`Text`) → Tailwind; o título vira `<h3>` de verdade (era `Text weight="medium"`, sem semântica de cabeçalho, então nenhum leitor de tela o alcançava pela navegação por headings); o ícone decorativo entra num chip com `aria-hidden`.

**Nota de procedência:** a entrada de dimensão 5 dizia "não trazer o corpo Tailwind — é dimensão 6". A tabela de pareamento produzida DEPOIS, pela varredura da dimensão 6, reclassificou: esta metade viaja junto e tem dependência **nenhuma** (ao contrário do E6, represado pelo F3). Vale a decisão mais recente, que é a informada. O escopo do CSS do Radix (F6) segue fora, como a mesma tabela manda.

## Testes

7 casos novos (Vitest + Testing Library). `data-testid="empty-state"` nasce junto do teste que o usa — não antes, senão vira peça morta.

| Mutação | Resultado |
| ------- | --------- |
| Título volta a ser `<p>`, sem semântica de cabeçalho | ⨯ falha |
| Sem a prop `action` (o beco sem saída original) | ⨯ falha |
| Ícone decorativo sem `aria-hidden` | ⨯ falha |
| Volta o ramo de linha de tabela (o HTML inválido original) | ⨯ falha |
| Sem o `data-testid` | ⨯ falha |

Nota de método: a primeira versão da mutação do ramo de tabela produziu JSX inválido e o vitest devolveu **"no tests"** em vez de uma falha. Sinal diferente de vermelho é sinal a auditar — refeita numa forma que compila, ela mata o teste certo.

## Gates

`corepack pnpm ci:check` ✅ 31 arquivos / 211 testes · `composer ci:check` ✅ exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
