### PR TITLE
[107]: fix(ui): 6 regras e 2 keyframes de toast que nunca casaram nada

### DIFF
--- a/.ai/rules/css.md
+++ b/.ai/rules/css.md
@@ -16,3 +16,6 @@ Os primitivos desligam o anel nativo do browser (`outline-none`) e desenham o pr
 
 ## Folha de terceiro entra em layer
 `@import` de CSS de biblioteca traz declarações fora de layer, que vencem o `@theme`. Hoje `@radix-ui/themes/styles.css` redeclara `--color-background` e sequestra `bg-background` no app inteiro — dívida registrada, ainda não paga. Ao acrescentar folha de terceiro, importe em `layer(...)` com a ordem declarada, ou reafirme explicitamente os tokens que ela pisa.
+
+## Estilo de toast que a API da lib expressa não vira CSS
+`react-hot-toast@2.6.0` emite **um** atributo de dado no DOM — `data-rht-toaster` — e anima entrada e saída por style inline derivado de `t.visible`. Seletor de CSS mirando `[data-state]` (isso é Radix) ou `[data-icon]` não casa nada e apodrece em silêncio, que foi o destino de 6 regras e 2 `@keyframes` em `app.css`. Cor de ícone é `iconTheme`, duração é `duration`, posição é `position`, severidade de anúncio é `ariaProps` — tudo em `lib/toast-config.ts`, travado por `resources/js/test/lib/toast-config.test.ts`. As classes `toast-custom`/`toast-success`/… existem só para o que o `toastOptions` não alcança (hoje, a borda esquerda por variante e o ajuste de sombra no escuro). Antes de escrever CSS contra markup de terceiro, confirme no `dist/` da lib que o gancho existe.

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -622,15 +622,19 @@ ul li span.text-sm {
     transition: all 0.2s ease-in-out !important;
 }
 
+/*
+ * A cor do ÍCONE de cada variante não mora aqui: quem a define é o
+ * `iconTheme` de `lib/toast-config.ts`, que é a API do react-hot-toast para
+ * isso. Existiam aqui 4 blocos `[class*='toast-icon'], [data-icon]` tentando
+ * o mesmo por CSS — e nenhum casava nada: a lib emite um único atributo de
+ * dado no DOM (`data-rht-toaster`), e classe com `toast-icon` não existe em
+ * lugar nenhum do projeto.
+ */
+
 /* Success toast */
 .toast-success {
     border-left: 4px solid var(--success) !important;
     background: var(--card) !important;
-}
-
-.toast-success [class*='toast-icon'],
-.toast-success [data-icon] {
-    color: var(--success) !important;
 }
 
 /* Error toast */
@@ -639,31 +643,16 @@ ul li span.text-sm {
     background: var(--card) !important;
 }
 
-.toast-error [class*='toast-icon'],
-.toast-error [data-icon] {
-    color: var(--destructive) !important;
-}
-
 /* Warning toast */
 .toast-warning {
     border-left: 4px solid var(--warning) !important;
     background: var(--card) !important;
 }
 
-.toast-warning [class*='toast-icon'],
-.toast-warning [data-icon] {
-    color: var(--warning) !important;
-}
-
 /* Info toast */
 .toast-info {
     border-left: 4px solid var(--info) !important;
     background: var(--card) !important;
-}
-
-.toast-info [class*='toast-icon'],
-.toast-info [data-icon] {
-    color: var(--info) !important;
 }
 
 /* Dark mode adjustments */
@@ -681,33 +670,12 @@ ul li span.text-sm {
     background: var(--card) !important;
 }
 
-/* Animation improvements */
-.toast-custom[data-state='entering'] {
-    animation: slideInRight 0.3s ease-out;
-}
-
-.toast-custom[data-state='exiting'] {
-    animation: slideOutRight 0.2s ease-in;
-}
-
-@keyframes slideInRight {
-    from {
-        transform: translateX(100%);
-        opacity: 0;
-    }
-    to {
-        transform: translateX(0);
-        opacity: 1;
-    }
-}
-
-@keyframes slideOutRight {
-    from {
-        transform: translateX(0);
-        opacity: 1;
-    }
-    to {
-        transform: translateX(100%);
-        opacity: 0;
-    }
-}
+/*
+ * Não há bloco de animação aqui de propósito. Existia um par
+ * `.toast-custom[data-state='entering'|'exiting']` com duas `@keyframes`
+ * próprias, e ele nunca rodou: `data-state` é atributo do Radix, não do
+ * react-hot-toast. A entrada e a saída que se vê na tela são as da própria
+ * lib, aplicadas por style inline a partir de `t.visible`. Não há classe nem
+ * atributo alternando entre entrar e sair para um seletor de CSS ancorar:
+ * mexer nessa animação é pelo `toastOptions` de `lib/toast-config.ts`.
+ */

--- a/resources/js/test/lib/toast-config.test.ts
+++ b/resources/js/test/lib/toast-config.test.ts
@@ -34,3 +34,24 @@ describe('ariaProps dos toasts', () => {
         expect(toastInfoOptions.ariaProps).toBeUndefined();
     });
 });
+
+/*
+ * A cor do ícone é `iconTheme`, e este é o único canal que funciona.
+ *
+ * `app.css` teve por meses 4 blocos `.toast-{variante} [class*='toast-icon'],
+ * [data-icon]` tentando o mesmo por CSS. Nenhum casava: o único atributo de
+ * dado que a lib emite no DOM é `data-rht-toaster`, e classe com `toast-icon`
+ * não existe em lugar nenhum do projeto. Foram apagados; estas asserções
+ * existem para que a próxima pessoa que quiser trocar a cor do ícone encontre
+ * o canal certo em vez de reescrever o CSS morto.
+ */
+describe('iconTheme dos toasts', () => {
+    it.each([
+        ['success', toastSuccessOptions, 'var(--success)'],
+        ['error', toastErrorOptions, 'var(--destructive)'],
+        ['warning', toastWarningOptions, 'var(--warning)'],
+        ['info', toastInfoOptions, 'var(--info)'],
+    ])('colors the %s icon through iconTheme, not through CSS', (_nome, options, cor) => {
+        expect(options.iconTheme?.primary).toBe(cor);
+    });
+});


### PR DESCRIPTION
Fatia **F32** da rodada harvest v2 (dimensão 6 — UI, achado interno do boilerplate).

## O fato

`react-hot-toast@2.6.0` emite **um** atributo de dado no DOM:

```
$ grep -oE '"data-[a-z-]+"' node_modules/react-hot-toast/dist/index.js | sort -u
"data-rht-toaster"
```

Não existe `data-state` — isso é vocabulário do Radix — nem `data-icon`.

## O que sai de `app.css`

| Bloco | Por que nunca rodou |
| ----- | ------------------- |
| 4× `.toast-{success,error,warning,info} [class*='toast-icon'], [data-icon]` | `data-icon` a lib não emite, e classe contendo `toast-icon` não existe em lugar nenhum do projeto — as únicas ocorrências da string eram os próprios seletores |
| `.toast-custom[data-state='entering']` e `[data-state='exiting']` | `data-state` não é emitido |
| `@keyframes slideInRight` e `slideOutRight` | existiam só para as duas regras acima |

A intenção dos 4 primeiros — pintar o ícone com a cor do estado — **já estava atendida pela API suportada**: `lib/toast-config.ts` define `iconTheme` nas 4 variantes. A animação que se vê na tela sempre foi a da própria lib, aplicada por style inline derivado de `t.visible` (`animation: ${…} 0.3s cubic-bezier(…)` no `dist/`), não por classe nem por atributo — não há gancho de CSS para ancorar.

O que **fica**: `.toast-custom` e a borda esquerda por variante, que são reais e cobrem o que o `toastOptions` não alcança.

## Evidência

- **4 asserções novas** em `test/lib/toast-config.test.ts` travando o `iconTheme` das 4 variantes — para que a próxima pessoa que quiser trocar a cor do ícone encontre o canal certo em vez de reescrever o CSS morto. Mutação (remover o `iconTheme` do success) mata.
- CSS do bundle: **824,70 kB → 824,00 kB** (gzip 104,18 → 104,03 kB). O ganho de bytes é pequeno e não é o ponto — o ponto é que CSS que não casa nada é desinformação: ele descreve um comportamento que o produto não tem.
- Regra nova em `.ai/rules/css.md`: antes de escrever CSS contra markup de terceiro, confirmar no `dist/` que o gancho existe.
- Gates: `composer ci:check` 416/2046, `corepack pnpm ci:check` 37 arquivos / 266 testes. Ambos exit 0.

Closes #107